### PR TITLE
feat: 전역 예외 처리 설정

### DIFF
--- a/src/main/java/com/testcar/car/common/exception/BadRequestException.java
+++ b/src/main/java/com/testcar/car/common/exception/BadRequestException.java
@@ -1,0 +1,10 @@
+package com.testcar.car.common.exception;
+
+
+import org.springframework.http.HttpStatus;
+
+public class BadRequestException extends BaseException {
+    public BadRequestException(BaseErrorCode errorCode) {
+        super(HttpStatus.BAD_REQUEST, errorCode);
+    }
+}

--- a/src/main/java/com/testcar/car/common/exception/BaseErrorCode.java
+++ b/src/main/java/com/testcar/car/common/exception/BaseErrorCode.java
@@ -1,0 +1,7 @@
+package com.testcar.car.common.exception;
+
+public interface BaseErrorCode {
+    String getCode();
+
+    String getMessage();
+}

--- a/src/main/java/com/testcar/car/common/exception/BaseException.java
+++ b/src/main/java/com/testcar/car/common/exception/BaseException.java
@@ -1,0 +1,20 @@
+package com.testcar.car.common.exception;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public class BaseException extends RuntimeException {
+    private HttpStatus httpStatus;
+    private String code;
+    private String message;
+
+    public BaseException(HttpStatus httpStatus, BaseErrorCode errorCode) {
+        this.httpStatus = httpStatus;
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/com/testcar/car/common/exception/ErrorCode.java
+++ b/src/main/java/com/testcar/car/common/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package com.testcar.car.common.exception;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** 에러 코드를 관리하기 위한 Enum 입니다 */
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode implements BaseErrorCode {
+
+    /* 공통 오류 */
+    _INTERNAL_SERVER_ERROR("C000", "서버 에러, 관리자에게 문의 바랍니다"),
+    _BAD_REQUEST("C001", "잘못된 요청입니다"),
+    _UNAUTHORIZED("C002", "권한이 없습니다");
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/testcar/car/common/exception/ErrorField.java
+++ b/src/main/java/com/testcar/car/common/exception/ErrorField.java
@@ -1,0 +1,35 @@
+package com.testcar.car.common.exception;
+
+
+import java.util.List;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+
+/** method argument exception 의 필드 오류를 설명하는 클래스 */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ErrorField {
+    private String field;
+
+    private String value;
+
+    private String reason;
+
+    public static List<ErrorField> from(BindingResult bindingResult) {
+        return bindingResult.getAllErrors().stream().map(ErrorField::from).toList();
+    }
+
+    private static ErrorField from(ObjectError objectError) {
+        final FieldError fieldError = (FieldError) objectError;
+        return new ErrorField(
+                fieldError.getField(),
+                Objects.toString(fieldError.getRejectedValue()),
+                fieldError.getDefaultMessage());
+    }
+}

--- a/src/main/java/com/testcar/car/common/exception/ForbiddenException.java
+++ b/src/main/java/com/testcar/car/common/exception/ForbiddenException.java
@@ -1,0 +1,10 @@
+package com.testcar.car.common.exception;
+
+
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenException extends BaseException {
+    public ForbiddenException(BaseErrorCode errorCode) {
+        super(HttpStatus.FORBIDDEN, errorCode);
+    }
+}

--- a/src/main/java/com/testcar/car/common/exception/InternalServerException.java
+++ b/src/main/java/com/testcar/car/common/exception/InternalServerException.java
@@ -1,0 +1,10 @@
+package com.testcar.car.common.exception;
+
+
+import org.springframework.http.HttpStatus;
+
+public class InternalServerException extends BaseException {
+    public InternalServerException(BaseErrorCode errorCode) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, errorCode);
+    }
+}

--- a/src/main/java/com/testcar/car/common/exception/NotFoundException.java
+++ b/src/main/java/com/testcar/car/common/exception/NotFoundException.java
@@ -1,0 +1,10 @@
+package com.testcar.car.common.exception;
+
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends BaseException {
+    public NotFoundException(BaseErrorCode errorCode) {
+        super(HttpStatus.NOT_FOUND, errorCode);
+    }
+}

--- a/src/main/java/com/testcar/car/common/exception/UnauthorizedException.java
+++ b/src/main/java/com/testcar/car/common/exception/UnauthorizedException.java
@@ -1,0 +1,10 @@
+package com.testcar.car.common.exception;
+
+
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends BaseException {
+    public UnauthorizedException(BaseErrorCode errorCode) {
+        super(HttpStatus.UNAUTHORIZED, errorCode);
+    }
+}

--- a/src/main/java/com/testcar/car/config/ExceptionAdvice.java
+++ b/src/main/java/com/testcar/car/config/ExceptionAdvice.java
@@ -1,0 +1,32 @@
+package com.testcar.car.config;
+
+import static com.testcar.car.common.exception.ErrorCode._INTERNAL_SERVER_ERROR;
+
+import com.testcar.car.common.exception.BaseException;
+import com.testcar.car.common.exception.InternalServerException;
+import com.testcar.car.common.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/** 전역 예외 처리를 하기 위한 핸들러 입니다 */
+@Slf4j
+@RestControllerAdvice
+public class ExceptionAdvice {
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
+        log.error("handleBaseException", e);
+        final ErrorResponse response = ErrorResponse.from(e);
+        return new ResponseEntity<>(response, e.getHttpStatus());
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleAllException(Exception e) {
+        log.error("Exception has occurred ", e);
+        final InternalServerException exception =
+                new InternalServerException(_INTERNAL_SERVER_ERROR);
+        final ErrorResponse response = ErrorResponse.from(exception);
+        return new ResponseEntity<>(response, exception.getHttpStatus());
+    }
+}

--- a/src/main/java/com/testcar/car/domains/carStock/ErrorCode.java
+++ b/src/main/java/com/testcar/car/domains/carStock/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.testcar.car.domains.carStock;
+
+
+import com.testcar.car.common.exception.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode implements BaseErrorCode {
+    CAR_NOT_FOUND("CAR001", "해당 차량을 찾을 수 없습니다.");
+
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
예외 처리와 그 응답에 대한 설정을 구현했습니다.
예외 코드는 각 도메인에서 관리하도록 interface 화 했습니다.
예외가 발생할 경우 advice 에서 응답을 가로채어 메세지를 가공하여 출력하도록 했습니다.