### PR TITLE
feat: 유저 토큰 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ repositories {
 }
 
 dependencies {
+	// configuration property binding
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -39,14 +42,15 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
 	// Validation
-	implementation('org.springframework.boot:spring-boot-starter-validation')
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// jwt
-	implementation(group: 'io.jsonwebtoken', name: 'jjwt', version: '0.11.5')
-	implementation('io.jsonwebtoken:jjwt:0.9.1')
+	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.11.5'
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
 
 	// Swagger
-	implementation ('org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4')
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/testcar/car/common/annotation/AuthMember.java
+++ b/src/main/java/com/testcar/car/common/annotation/AuthMember.java
@@ -1,0 +1,13 @@
+package com.testcar.car.common.annotation;
+
+
+import io.swagger.v3.oas.annotations.Hidden;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Hidden
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthMember {}

--- a/src/main/java/com/testcar/car/common/auth/JwtConstant.java
+++ b/src/main/java/com/testcar/car/common/auth/JwtConstant.java
@@ -1,0 +1,10 @@
+package com.testcar.car.common.auth;
+
+public class JwtConstant {
+    private JwtConstant() {}
+
+    public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 7; // 7일
+    public static final String CLAIM_KEY = "userId";
+    public static final String HEADER_KEY = "type";
+    public static final String HEADER_VALUE = "user";
+}

--- a/src/main/java/com/testcar/car/common/auth/JwtProperty.java
+++ b/src/main/java/com/testcar/car/common/auth/JwtProperty.java
@@ -1,0 +1,13 @@
+package com.testcar.car.common.auth;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperty {
+    private String secretKey;
+}

--- a/src/main/java/com/testcar/car/common/auth/JwtService.java
+++ b/src/main/java/com/testcar/car/common/auth/JwtService.java
@@ -1,0 +1,73 @@
+package com.testcar.car.common.auth;
+
+import static com.testcar.car.common.auth.JwtConstant.ACCESS_TOKEN_EXPIRE_TIME;
+import static com.testcar.car.common.auth.JwtConstant.CLAIM_KEY;
+import static com.testcar.car.common.auth.JwtConstant.HEADER_KEY;
+import static com.testcar.car.common.auth.JwtConstant.HEADER_VALUE;
+import static com.testcar.car.common.exception.ErrorCode.EMPTY_TOKEN;
+import static com.testcar.car.common.exception.ErrorCode.INVALID_TOKEN;
+
+import com.testcar.car.common.exception.UnauthorizedException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+    private static final String BEARER = "^Bearer( )*";
+    private final JwtProperty jwtProperty;
+
+    public String generateAccessToken(Long userId) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setHeaderParam(HEADER_KEY, HEADER_VALUE)
+                .claim(CLAIM_KEY, userId)
+                .setIssuedAt(now)
+                .setExpiration(getExpiryDate())
+                .signWith(SignatureAlgorithm.HS256, jwtProperty.getSecretKey())
+                .compact();
+    }
+
+    public Long getUserId() {
+        final String accessToken = getBearerToken();
+        return parseUserId(accessToken);
+    }
+
+    private String getBearerToken() {
+        HttpServletRequest request =
+                ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
+                        .getRequest();
+        String accessToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new UnauthorizedException(EMPTY_TOKEN);
+        }
+
+        return accessToken.replaceAll(BEARER, "");
+    }
+
+    private Long parseUserId(String token) {
+        try {
+            Jws<Claims> claims =
+                    Jwts.parser().setSigningKey(jwtProperty.getSecretKey()).parseClaimsJws(token);
+            return claims.getBody().get(CLAIM_KEY, Long.class);
+        } catch (Exception ignored) {
+            throw new UnauthorizedException(INVALID_TOKEN);
+        }
+    }
+
+    private Date getExpiryDate() {
+        return new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME);
+    }
+}

--- a/src/main/java/com/testcar/car/common/exception/ErrorCode.java
+++ b/src/main/java/com/testcar/car/common/exception/ErrorCode.java
@@ -4,15 +4,15 @@ package com.testcar.car.common.exception;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-/** 에러 코드를 관리하기 위한 Enum 입니다 */
+/** 에러 코드를 관리하기 위한 서버 공통 Enum 입니다 */
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode implements BaseErrorCode {
-
-    /* 공통 오류 */
-    _INTERNAL_SERVER_ERROR("C000", "서버 에러, 관리자에게 문의 바랍니다"),
-    _BAD_REQUEST("C001", "잘못된 요청입니다"),
-    _UNAUTHORIZED("C002", "권한이 없습니다");
+    INTERNAL_SERVER_ERROR("C000", "서버 에러, 관리자에게 문의 바랍니다."),
+    BAD_REQUEST("C001", "잘못된 요청입니다."),
+    UNAUTHORIZED("C002", "권한이 없습니다."),
+    EMPTY_TOKEN("C003", "토큰이 존재하지 않습니다."),
+    INVALID_TOKEN("C004", "유효하지 않은 토큰입니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/testcar/car/common/resolver/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/testcar/car/common/resolver/AuthMemberArgumentResolver.java
@@ -1,0 +1,42 @@
+package com.testcar.car.common.resolver;
+
+import static com.testcar.car.domains.member.ErrorCode.MEMBER_NOT_FOUND;
+
+import com.testcar.car.common.annotation.AuthMember;
+import com.testcar.car.common.auth.JwtService;
+import com.testcar.car.common.exception.NotFoundException;
+import com.testcar.car.domains.member.Member;
+import com.testcar.car.domains.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
+    private final JwtService jwtService;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthMember.class);
+    }
+
+    @Override
+    @Nullable
+    public Member resolveArgument(
+            MethodParameter parameter,
+            @Nullable ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            @Nullable WebDataBinderFactory binderFactory) {
+        final Long userId = jwtService.getUserId();
+        return memberRepository
+                .findByIdAndDeletedFalse(userId)
+                .orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/testcar/car/common/response/ErrorResponse.java
+++ b/src/main/java/com/testcar/car/common/response/ErrorResponse.java
@@ -1,6 +1,7 @@
 package com.testcar.car.common.response;
 
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.testcar.car.common.exception.BaseException;
 import com.testcar.car.common.exception.ErrorField;
 import java.time.LocalDateTime;
@@ -19,8 +20,10 @@ public class ErrorResponse {
     private final boolean success = false;
     private int status;
     private String message;
-    private List<ErrorField> errors;
     private String code;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<ErrorField> errors;
 
     public static ErrorResponse from(BaseException exception) {
         return ErrorResponse.builder()

--- a/src/main/java/com/testcar/car/common/response/ErrorResponse.java
+++ b/src/main/java/com/testcar/car/common/response/ErrorResponse.java
@@ -1,0 +1,42 @@
+package com.testcar.car.common.response;
+
+
+import com.testcar.car.common.exception.BaseException;
+import com.testcar.car.common.exception.ErrorField;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.BindingResult;
+
+@Slf4j
+@Getter
+@Builder
+public class ErrorResponse {
+    private final String timestamp = LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
+    private final boolean success = false;
+    private int status;
+    private String message;
+    private List<ErrorField> errors;
+    private String code;
+
+    public static ErrorResponse from(BaseException exception) {
+        return ErrorResponse.builder()
+                .message(exception.getMessage())
+                .status(exception.getHttpStatus().value())
+                .errors(List.of())
+                .code(exception.getCode())
+                .build();
+    }
+
+    public static ErrorResponse of(BaseException exception, BindingResult bindingResult) {
+        return ErrorResponse.builder()
+                .message(exception.getMessage())
+                .status(exception.getHttpStatus().value())
+                .errors(ErrorField.from(bindingResult))
+                .code(exception.getCode())
+                .build();
+    }
+}

--- a/src/main/java/com/testcar/car/common/response/SuccessResponse.java
+++ b/src/main/java/com/testcar/car/common/response/SuccessResponse.java
@@ -1,0 +1,25 @@
+package com.testcar.car.common.response;
+
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SuccessResponse<T> {
+    private final String timestamp = LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
+    private final Boolean success = true;
+    private int status;
+    private final String message = "요청에 성공했습니다.";
+    private T result;
+
+    public static <T> SuccessResponse<T> from(T result) {
+        return new SuccessResponse<>(200, result);
+    }
+
+    public static <T> SuccessResponse<T> from(int status, T result) {
+        return new SuccessResponse<>(status, result);
+    }
+}

--- a/src/main/java/com/testcar/car/config/ConfigurationPropertiesConfig.java
+++ b/src/main/java/com/testcar/car/config/ConfigurationPropertiesConfig.java
@@ -1,0 +1,10 @@
+package com.testcar.car.config;
+
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+
+/** application.yml 환경변수를 바인딩하여 등록하는 설정 빈 */
+@Configuration
+@ConfigurationPropertiesScan(basePackages = "com.testcar.car")
+public class ConfigurationPropertiesConfig {}

--- a/src/main/java/com/testcar/car/config/ExceptionAdvice.java
+++ b/src/main/java/com/testcar/car/config/ExceptionAdvice.java
@@ -1,6 +1,6 @@
 package com.testcar.car.config;
 
-import static com.testcar.car.common.exception.ErrorCode._INTERNAL_SERVER_ERROR;
+import static com.testcar.car.common.exception.ErrorCode.INTERNAL_SERVER_ERROR;
 
 import com.testcar.car.common.exception.BaseException;
 import com.testcar.car.common.exception.InternalServerException;
@@ -25,7 +25,7 @@ public class ExceptionAdvice {
     protected ResponseEntity<ErrorResponse> handleAllException(Exception e) {
         log.error("Exception has occurred ", e);
         final InternalServerException exception =
-                new InternalServerException(_INTERNAL_SERVER_ERROR);
+                new InternalServerException(INTERNAL_SERVER_ERROR);
         final ErrorResponse response = ErrorResponse.from(exception);
         return new ResponseEntity<>(response, exception.getHttpStatus());
     }

--- a/src/main/java/com/testcar/car/config/JpaConfig.java
+++ b/src/main/java/com/testcar/car/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.testcar.car.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+/** Jpa 엔티티 관련 변경감지를 활성화하는 설정 빈 */
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {}

--- a/src/main/java/com/testcar/car/config/SuccessResponseAdvice.java
+++ b/src/main/java/com/testcar/car/config/SuccessResponseAdvice.java
@@ -1,0 +1,50 @@
+package com.testcar.car.config;
+
+
+import com.testcar.car.common.response.SuccessResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/** http status 2xx 의 성공 응답을 공통적으로 처리하는 advice */
+@RestControllerAdvice(basePackages = "com.testcar.car")
+public class SuccessResponseAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        Class<?> parameterType = returnType.getParameterType();
+        return !ResponseEntity.class.equals(parameterType) && !void.class.equals(parameterType);
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body,
+            MethodParameter returnType,
+            MediaType selectedContentType,
+            Class selectedConverterType,
+            ServerHttpRequest request,
+            ServerHttpResponse response) {
+        HttpServletResponse servletResponse =
+                ((ServletServerHttpResponse) response).getServletResponse();
+
+        int status = servletResponse.getStatus();
+        HttpStatus resolve = HttpStatus.resolve(status);
+
+        if (resolve == null) {
+            return body;
+        }
+
+        if (resolve.is2xxSuccessful()) {
+            return new SuccessResponse<>(status, body);
+        }
+
+        return body;
+    }
+}

--- a/src/main/java/com/testcar/car/config/SwaggerConfig.java
+++ b/src/main/java/com/testcar/car/config/SwaggerConfig.java
@@ -1,0 +1,41 @@
+package com.testcar.car.config;
+
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        Info info =
+                new Info().version("v1").title("시험차량 관리 서비스").description("시험차량 관리 서비스 API 명세서");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement();
+        securityRequirement.addList("JWT");
+
+        Components components =
+                new Components()
+                        .addSecuritySchemes(
+                                "JWT",
+                                new SecurityScheme()
+                                        .name("JWT")
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}

--- a/src/main/java/com/testcar/car/config/WebConfig.java
+++ b/src/main/java/com/testcar/car/config/WebConfig.java
@@ -1,0 +1,30 @@
+package com.testcar.car.config;
+
+
+import com.testcar.car.common.resolver.AuthMemberArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final AuthMemberArgumentResolver authMemberArgumentResolver;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authMemberArgumentResolver);
+    }
+}

--- a/src/main/java/com/testcar/car/domains/auth/AuthController.java
+++ b/src/main/java/com/testcar/car/domains/auth/AuthController.java
@@ -1,0 +1,24 @@
+package com.testcar.car.domains.auth;
+
+
+import com.testcar.car.domains.auth.model.LoginRequest;
+import com.testcar.car.domains.auth.model.TokenResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public TokenResponse login(@Valid @RequestBody LoginRequest request) {
+        final String accessToken = authService.login(request);
+        return new TokenResponse(accessToken);
+    }
+}

--- a/src/main/java/com/testcar/car/domains/auth/AuthService.java
+++ b/src/main/java/com/testcar/car/domains/auth/AuthService.java
@@ -1,0 +1,21 @@
+package com.testcar.car.domains.auth;
+
+
+import com.testcar.car.common.auth.JwtService;
+import com.testcar.car.domains.auth.model.LoginRequest;
+import com.testcar.car.domains.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+    private final JwtService jwtService;
+    private final MemberRepository memberRepository;
+
+    public String login(LoginRequest request) {
+        return jwtService.generateAccessToken(1L);
+    }
+}

--- a/src/main/java/com/testcar/car/domains/auth/model/LoginRequest.java
+++ b/src/main/java/com/testcar/car/domains/auth/model/LoginRequest.java
@@ -1,0 +1,19 @@
+package com.testcar.car.domains.auth.model;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+    @NotBlank
+    @Schema(description = "이메일", example = "kls1998@naver.com")
+    private String email;
+
+    @NotBlank
+    @Schema(description = "비밀번호", example = "1234")
+    private String password;
+}

--- a/src/main/java/com/testcar/car/domains/auth/model/TokenResponse.java
+++ b/src/main/java/com/testcar/car/domains/auth/model/TokenResponse.java
@@ -1,0 +1,11 @@
+package com.testcar.car.domains.auth.model;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponse {
+    private String accessToken;
+}

--- a/src/main/java/com/testcar/car/domains/health/HelloController.java
+++ b/src/main/java/com/testcar/car/domains/health/HelloController.java
@@ -1,0 +1,12 @@
+package com.testcar.car.domains.health;
+
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** server health check 를 수행하는 컨트롤러 */
+@RestController
+public class HelloController {
+    @GetMapping("/")
+    public void hello() {}
+}

--- a/src/main/java/com/testcar/car/domains/member/ErrorCode.java
+++ b/src/main/java/com/testcar/car/domains/member/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.testcar.car.domains.member;
+
+
+import com.testcar.car.common.exception.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode implements BaseErrorCode {
+    MEMBER_NOT_FOUND("MEM001", "해당 사용자를 찾을 수 없습니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/testcar/car/domains/member/MemberController.java
+++ b/src/main/java/com/testcar/car/domains/member/MemberController.java
@@ -1,0 +1,19 @@
+package com.testcar.car.domains.member;
+
+
+import com.testcar.car.common.annotation.AuthMember;
+import com.testcar.car.domains.member.model.MemberResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+    @GetMapping("/me")
+    public MemberResponse getMe(@AuthMember Member member) {
+        return MemberResponse.from(member);
+    }
+}

--- a/src/main/java/com/testcar/car/domains/member/MemberRepository.java
+++ b/src/main/java/com/testcar/car/domains/member/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.testcar.car.domains.member;
+
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByIdAndDeletedFalse(Long id);
+}

--- a/src/main/java/com/testcar/car/domains/member/MemberService.java
+++ b/src/main/java/com/testcar/car/domains/member/MemberService.java
@@ -1,0 +1,20 @@
+package com.testcar.car.domains.member;
+
+
+import com.testcar.car.common.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public Member findById(Long id) {
+        return memberRepository
+                .findByIdAndDeletedFalse(id)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/testcar/car/domains/member/model/MemberResponse.java
+++ b/src/main/java/com/testcar/car/domains/member/model/MemberResponse.java
@@ -1,0 +1,27 @@
+package com.testcar.car.domains.member.model;
+
+
+import com.testcar.car.domains.member.Member;
+import com.testcar.car.domains.member.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MemberResponse {
+    private Long id;
+    private String email;
+    private String name;
+    private Role role;
+
+    public static MemberResponse from(Member member) {
+        return MemberResponse.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .name(member.getName())
+                .role(member.getRole())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,6 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY:secret1231241232141asdasdwe}

--- a/src/main/resources/db/migration/V1__Init.sql
+++ b/src/main/resources/db/migration/V1__Init.sql
@@ -1,5 +1,5 @@
 CREATE TABLE `Member` (
-    `id`	        BIGINT	        NOT NULL	COMMENT '사용자 id',
+    `id`	        BIGINT	        NOT NULL	AUTO_INCREMENT COMMENT '사용자 id',
     `departmentId`	BIGINT	        NOT NULL	COMMENT '부서 id',
     `email`	        VARCHAR(50)	    NOT NULL	COMMENT '이메일(계정)',
     `password`	    VARCHAR(50)	    NOT NULL	COMMENT '패스워드',
@@ -12,7 +12,7 @@ CREATE TABLE `Member` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `Department` (
-    `id`	        BIGINT	        NOT NULL	COMMENT '부서 id',
+    `id`	        BIGINT	        NOT NULL	AUTO_INCREMENT COMMENT '부서 id',
     `name`	        VARCHAR(20)	    NOT NULL	COMMENT '부서명',
     `createdAt`	    DATETIME(6)	    NOT NULL	COMMENT '생성일시',
     `updatedAt`	    DATETIME(6)	    NOT NULL	COMMENT '수정일시',
@@ -21,7 +21,7 @@ CREATE TABLE `Department` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `Car` (
-    `id`	        BIGINT	        NOT NULL	COMMENT '차량 id',
+    `id`	        BIGINT	        NOT NULL	AUTO_INCREMENT COMMENT '차량 id',
     `name`	        VARCHAR(50)	    NOT NULL	COMMENT '차량명',
     `releasedAt`	DATETIME(6)	    NOT NULL	COMMENT '출시일자',
     `type`	        VARCHAR(10)	    NOT NULL	COMMENT '처종',
@@ -32,7 +32,7 @@ CREATE TABLE `Car` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `CarStock` (
-    `id`	        BIGINT	        NOT NULL	COMMENT '차량재고 id',
+    `id`	        BIGINT	        NOT NULL	AUTO_INCREMENT COMMENT '차량재고 id',
     `carId`	        BIGINT	        NOT NULL	COMMENT '차량 id',
     `stockNumber`	VARCHAR(12)	    NOT NULL	COMMENT '재고번호',
     `status`	    VARCHAR(10)	    NOT NULL	COMMENT '재고상태',
@@ -43,7 +43,7 @@ CREATE TABLE `CarStock` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `CarReservation` (
-    `id`	        BIGINT	        NOT NULL	COMMENT '시험차량 대여 id',
+    `id`	        BIGINT	        NOT NULL	AUTO_INCREMENT COMMENT '시험차량 대여 id',
     `memberId`	    BIGINT	        NOT NULL	COMMENT '사용자 id',
     `carStockId`	BIGINT	        NOT NULL	COMMENT '차량재고 id',
     `reservedAt`	DATETIME(6)	    NOT NULL	COMMENT '대여시각',
@@ -55,7 +55,7 @@ CREATE TABLE `CarReservation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `Track` (
-    `id`	        BIGINT	        NOT NULL	COMMENT '시험장 id',
+    `id`	        BIGINT	        NOT NULL	AUTO_INCREMENT COMMENT '시험장 id',
     `name`	        VARCHAR(50)	    NOT NULL	COMMENT '시험장 이름',
     `location`	    VARCHAR(255)	NOT NULL	COMMENT '위치',
     `latitude`	    DOUBLE	            NULL	COMMENT '위도',
@@ -69,7 +69,7 @@ CREATE TABLE `Track` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `TrackReservation` (
-    `id`	        BIGINT	        NOT NULL	COMMENT '주행시험장 대여 id',
+    `id`	        BIGINT	        NOT NULL	AUTO_INCREMENT COMMENT '주행시험장 대여 id',
     `memberId`	    BIGINT	        NOT NULL	COMMENT '사용자 id',
     `trackId`	    BIGINT	        NOT NULL	COMMENT '시험장 id',
     `reservedAt`	DATETIME(6)	    NOT NULL	COMMENT '예약시각',
@@ -81,7 +81,7 @@ CREATE TABLE `TrackReservation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `CarTest` (
-    `id`	        BIGINT	        NOT NULL	COMMENT '주행시험 이력 id',
+    `id`	        BIGINT	        NOT NULL	AUTO_INCREMENT COMMENT '주행시험 이력 id',
     `memberId`	    BIGINT	        NOT NULL	COMMENT '사용자 id',
     `trackId`	    BIGINT	        NOT NULL	COMMENT '시험장 id',
     `carStockId`	BIGINT	        NOT NULL	COMMENT '차량재고 id',
@@ -95,7 +95,7 @@ CREATE TABLE `CarTest` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `GasStation` (
-    `id`	        BIGINT	        NOT NULL	COMMENT '주유소 id',
+    `id`	        BIGINT	        NOT NULL	AUTO_INCREMENT COMMENT '주유소 id',
     `name`	        VARCHAR(50)	    NOT NULL	COMMENT '이름',
     `createdAt`	    DATETIME(6)	    NOT NULL	COMMENT '생성일시',
     `updatedAt`	    DATETIME(6)	    NOT NULL	COMMENT '수정일시',
@@ -104,7 +104,7 @@ CREATE TABLE `GasStation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `GasStationHistory` (
-    `id`	        BIGINT	        NOT NULL	COMMENT '주유소 이용 id',
+    `id`	        BIGINT	        NOT NULL	AUTO_INCREMENT COMMENT '주유소 이용 id',
     `memberId`	    BIGINT	        NOT NULL	COMMENT '사용자 id',
     `gasStationId`	BIGINT	        NOT NULL	COMMENT '주유소 id',
     `carStockId`	BIGINT	        NOT NULL	COMMENT '차량재고 id',


### PR DESCRIPTION
jwt 엑세스 토큰을 이용한 로그인을 구현했습니다.
커스텀 interceptor 를 통해 유저의 로그인을 확인하고 정보를 응답하도록 했습니다.
관련하여 공통 응답 및 공통 에러 처리 로직을 구현하였습니다.