### PR TITLE
fix: 서버 에러 수정

### DIFF
--- a/src/main/java/com/testcar/car/config/ExceptionAdvice.java
+++ b/src/main/java/com/testcar/car/config/ExceptionAdvice.java
@@ -1,12 +1,17 @@
 package com.testcar.car.config;
 
+import static com.testcar.car.common.exception.ErrorCode.BAD_REQUEST;
 import static com.testcar.car.common.exception.ErrorCode.INTERNAL_SERVER_ERROR;
 
+import com.testcar.car.common.exception.BadRequestException;
 import com.testcar.car.common.exception.BaseException;
 import com.testcar.car.common.exception.InternalServerException;
 import com.testcar.car.common.response.ErrorResponse;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,6 +19,26 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice
 public class ExceptionAdvice {
+    /** Request Param 필수 파라미터에 대한 예외 처리 */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    protected ResponseEntity<ErrorResponse>  handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException e) {
+        log.warn("MissingServletRequestParameterException. error message: request field error");
+        final BadRequestException exception = new BadRequestException(BAD_REQUEST);
+        final ErrorResponse response = ErrorResponse.from(exception);
+        return new ResponseEntity<>(response, e.getStatusCode());
+    }
+
+    /** Request body 파라미터에 대한 예외 처리 */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e) {
+        log.warn("MethodArgumentNotValidException. error message: request field error");
+        final BadRequestException exception = new BadRequestException(BAD_REQUEST);
+        final ErrorResponse response = ErrorResponse.of(exception, e.getBindingResult());
+        return new ResponseEntity<>(response, e.getStatusCode());
+    }
+
     @ExceptionHandler
     protected ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
         log.error("handleBaseException", e);

--- a/src/main/java/com/testcar/car/config/ExceptionAdvice.java
+++ b/src/main/java/com/testcar/car/config/ExceptionAdvice.java
@@ -7,7 +7,6 @@ import com.testcar.car.common.exception.BadRequestException;
 import com.testcar.car.common.exception.BaseException;
 import com.testcar.car.common.exception.InternalServerException;
 import com.testcar.car.common.response.ErrorResponse;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -21,7 +20,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class ExceptionAdvice {
     /** Request Param 필수 파라미터에 대한 예외 처리 */
     @ExceptionHandler(MissingServletRequestParameterException.class)
-    protected ResponseEntity<ErrorResponse>  handleMissingServletRequestParameterException(
+    protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
             MissingServletRequestParameterException e) {
         log.warn("MissingServletRequestParameterException. error message: request field error");
         final BadRequestException exception = new BadRequestException(BAD_REQUEST);

--- a/src/main/java/com/testcar/car/domains/car/CarService.java
+++ b/src/main/java/com/testcar/car/domains/car/CarService.java
@@ -48,6 +48,9 @@ public class CarService {
     /** 차량 정보를 업데이트 합니다. */
     public Car updateById(Long carId, RegisterCarRequest request) {
         final Car car = this.findById(carId);
+        if (!car.getName().equals(request.getName())) {
+            validateNameNotDuplicated(request.getName());
+        }
         final Car updateMember = createEntity(request);
         car.update(updateMember);
         return carRepository.save(car);
@@ -62,7 +65,6 @@ public class CarService {
 
     /** 영속되지 않은 차량 엔티티를 생성합니다. */
     private Car createEntity(RegisterCarRequest request) {
-        validateNameNotDuplicated(request.getName());
         return Car.builder()
                 .name(request.getName())
                 .type(request.getType())

--- a/src/main/java/com/testcar/car/domains/car/model/vo/CarFilterCondition.java
+++ b/src/main/java/com/testcar/car/domains/car/model/vo/CarFilterCondition.java
@@ -2,11 +2,9 @@ package com.testcar.car.domains.car.model.vo;
 
 
 import com.testcar.car.common.annotation.DateFormat;
-import com.testcar.car.common.annotation.DateTimeFormat;
 import com.testcar.car.domains.car.entity.Type;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/main/java/com/testcar/car/domains/car/model/vo/CarFilterCondition.java
+++ b/src/main/java/com/testcar/car/domains/car/model/vo/CarFilterCondition.java
@@ -1,9 +1,11 @@
 package com.testcar.car.domains.car.model.vo;
 
 
+import com.testcar.car.common.annotation.DateFormat;
 import com.testcar.car.common.annotation.DateTimeFormat;
 import com.testcar.car.domains.car.entity.Type;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
@@ -17,11 +19,11 @@ public class CarFilterCondition {
     @Schema(description = "차종", example = "null", implementation = Type.class)
     private Type type;
 
-    @DateTimeFormat
+    @DateFormat
     @Schema(description = "등록일자 시작일", example = "null")
-    private LocalDateTime startDate;
+    private LocalDate startDate;
 
-    @DateTimeFormat
+    @DateFormat
     @Schema(description = "등록일자 종료일", example = "null")
-    private LocalDateTime endDate;
+    private LocalDate endDate;
 }

--- a/src/main/java/com/testcar/car/domains/car/repository/CarCustomRepositoryImpl.java
+++ b/src/main/java/com/testcar/car/domains/car/repository/CarCustomRepositoryImpl.java
@@ -8,7 +8,7 @@ import com.testcar.car.common.entity.BaseQueryDslRepository;
 import com.testcar.car.domains.car.entity.Car;
 import com.testcar.car.domains.car.entity.Type;
 import com.testcar.car.domains.car.model.vo.CarFilterCondition;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -64,7 +64,7 @@ public class CarCustomRepositoryImpl implements CarCustomRepository, BaseQueryDs
         return type == null ? null : car.type.eq(type);
     }
 
-    private BooleanExpression createdAtBetween(LocalDateTime begin, LocalDateTime end) {
+    private BooleanExpression createdAtBetween(LocalDate begin, LocalDate end) {
         return dateTimeBetween(car.createdAt, begin, end);
     }
 }

--- a/src/main/java/com/testcar/car/domains/carStock/CarStockController.java
+++ b/src/main/java/com/testcar/car/domains/carStock/CarStockController.java
@@ -5,12 +5,14 @@ import com.testcar.car.common.annotation.RoleAllowed;
 import com.testcar.car.common.response.PageResponse;
 import com.testcar.car.domains.carStock.entity.CarStock;
 import com.testcar.car.domains.carStock.model.CarStockResponse;
+import com.testcar.car.domains.carStock.model.DeleteCarStockRequest;
 import com.testcar.car.domains.carStock.model.RegisterCarStockRequest;
 import com.testcar.car.domains.carStock.model.UpdateCarStockRequest;
 import com.testcar.car.domains.carStock.model.vo.CarStockFilterCondition;
 import com.testcar.car.domains.member.Role;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
@@ -67,11 +69,11 @@ public class CarStockController {
         return CarStockResponse.from(carStock);
     }
 
-    @DeleteMapping("/{carStockId}")
+    @DeleteMapping
     @RoleAllowed(role = Role.ADMIN)
     @Operation(summary = "[재고 관리] 재고 삭제", description = "(관리자) 차량 재고를 삭제합니다.")
-    public CarStockResponse delete(@PathVariable Long carStockId) {
-        final CarStock carStock = carStockService.deleteById(carStockId);
-        return CarStockResponse.from(carStock);
+    public List<Long> delete(@Valid @RequestBody DeleteCarStockRequest request) {
+        carStockService.deleteAll(request);
+        return request.getIds();
     }
 }

--- a/src/main/java/com/testcar/car/domains/carStock/model/CarStockResponse.java
+++ b/src/main/java/com/testcar/car/domains/carStock/model/CarStockResponse.java
@@ -2,7 +2,6 @@ package com.testcar.car.domains.carStock.model;
 
 
 import com.testcar.car.common.annotation.DateFormat;
-import com.testcar.car.common.annotation.DateTimeFormat;
 import com.testcar.car.domains.car.entity.Type;
 import com.testcar.car.domains.carStock.entity.CarStock;
 import com.testcar.car.domains.carStock.entity.StockStatus;

--- a/src/main/java/com/testcar/car/domains/carStock/model/CarStockResponse.java
+++ b/src/main/java/com/testcar/car/domains/carStock/model/CarStockResponse.java
@@ -1,9 +1,13 @@
 package com.testcar.car.domains.carStock.model;
 
 
+import com.testcar.car.common.annotation.DateFormat;
+import com.testcar.car.common.annotation.DateTimeFormat;
+import com.testcar.car.domains.car.entity.Type;
 import com.testcar.car.domains.carStock.entity.CarStock;
 import com.testcar.car.domains.carStock.entity.StockStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,15 +23,24 @@ public class CarStockResponse {
     @Schema(description = "차량 재고번호", example = "2023010300001")
     private final String stockNumber;
 
+    @Schema(description = "차종", example = "SEDAN", implementation = Type.class)
+    private final Type type;
+
     @Schema(description = "재고 상태", example = "AVAILABLE", implementation = StockStatus.class)
     private final StockStatus status;
+
+    @DateFormat
+    @Schema(description = "등록일시", example = "2021-01-01 00:00:00")
+    private final LocalDateTime createdAt;
 
     public static CarStockResponse from(CarStock carStock) {
         return CarStockResponse.builder()
                 .id(carStock.getId())
                 .name(carStock.getCar().getName())
+                .type(carStock.getCar().getType())
                 .stockNumber(carStock.getStockNumber())
                 .status(carStock.getStatus())
+                .createdAt(carStock.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/testcar/car/domains/carStock/model/DeleteCarStockRequest.java
+++ b/src/main/java/com/testcar/car/domains/carStock/model/DeleteCarStockRequest.java
@@ -1,16 +1,12 @@
 package com.testcar.car.domains.carStock.model;
 
 
-import com.testcar.car.domains.carStock.entity.StockStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.Getter;
-import org.hibernate.validator.constraints.Length;
 
 @Getter
 public class DeleteCarStockRequest {

--- a/src/main/java/com/testcar/car/domains/carStock/model/DeleteCarStockRequest.java
+++ b/src/main/java/com/testcar/car/domains/carStock/model/DeleteCarStockRequest.java
@@ -1,0 +1,20 @@
+package com.testcar.car.domains.carStock.model;
+
+
+import com.testcar.car.domains.carStock.entity.StockStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+public class DeleteCarStockRequest {
+    @NotEmpty
+    @Schema(description = "차량 재고 ID", example = "[1, 2, 3]")
+    private List<@NotNull @Positive Long> ids;
+}

--- a/src/main/java/com/testcar/car/domains/carStock/model/RegisterCarStockRequest.java
+++ b/src/main/java/com/testcar/car/domains/carStock/model/RegisterCarStockRequest.java
@@ -11,13 +11,12 @@ import org.hibernate.validator.constraints.Length;
 
 @Getter
 public class RegisterCarStockRequest {
-    @NotBlank
-    @Length(max = 20)
-    @Schema(description = "차량명", example = "아반떼")
-    private String name;
+    @NotNull
+    @Schema(description = "차량 ID", example = "아반떼")
+    private Long carId;
 
     @NotBlank
-    @Pattern(regexp = "^[0-9]{13}$")
+    @Pattern(regexp = "^[0-9]{12}$")
     @Schema(description = "차량 재고번호", example = "2023010300001")
     private String stockNumber;
 

--- a/src/main/java/com/testcar/car/domains/carStock/model/RegisterCarStockRequest.java
+++ b/src/main/java/com/testcar/car/domains/carStock/model/RegisterCarStockRequest.java
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
-import org.hibernate.validator.constraints.Length;
 
 @Getter
 public class RegisterCarStockRequest {

--- a/src/main/java/com/testcar/car/domains/carStock/model/UpdateCarStockRequest.java
+++ b/src/main/java/com/testcar/car/domains/carStock/model/UpdateCarStockRequest.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 @Getter
 public class UpdateCarStockRequest {
     @NotBlank
-    @Pattern(regexp = "^[0-9]{13}$")
+    @Pattern(regexp = "^[0-9]{12}$")
     @Schema(description = "차량 재고번호", example = "2023010300001")
     private String stockNumber;
 

--- a/src/main/java/com/testcar/car/domains/carStock/model/vo/CarStockFilterCondition.java
+++ b/src/main/java/com/testcar/car/domains/carStock/model/vo/CarStockFilterCondition.java
@@ -9,6 +9,9 @@ import lombok.Setter;
 @Getter
 @Setter
 public class CarStockFilterCondition {
+    @Schema(description = "차량 id", example = "null")
+    private Long carId;
+
     @Schema(description = "차량명", example = "null")
     private String name;
 

--- a/src/main/java/com/testcar/car/domains/carStock/repository/CarStockCustomRepositoryImpl.java
+++ b/src/main/java/com/testcar/car/domains/carStock/repository/CarStockCustomRepositoryImpl.java
@@ -41,6 +41,7 @@ public class CarStockCustomRepositoryImpl
                         .from(carStock)
                         .where(
                                 notDeleted(carStock),
+                                carIdEqOrNull(condition.getCarId()),
                                 carNameContainsOrNull(condition.getName()),
                                 stockNumberEqOrNull(condition.getStockNumber()),
                                 stockStatusEqOrNull(condition.getStatus()))
@@ -62,6 +63,10 @@ public class CarStockCustomRepositoryImpl
                                         car.name.asc()))
                         .fetch();
         return PageableExecutionUtils.getPage(carStocks, pageable, coveringIndex::size);
+    }
+
+    private BooleanExpression carIdEqOrNull(Long carId) {
+        return carId == null ? null : carStock.car.id.eq(carId);
     }
 
     private BooleanExpression carNameContainsOrNull(String name) {

--- a/src/main/java/com/testcar/car/domains/carStock/repository/CarStockRepository.java
+++ b/src/main/java/com/testcar/car/domains/carStock/repository/CarStockRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CarStockRepository
         extends JpaRepository<CarStock, Long>, CarStockCustomRepository {
     Optional<CarStock> findByIdAndDeletedFalse(Long id);
+
     List<CarStock> findAllByIdInAndDeletedFalse(List<Long> ids);
+
     boolean existsByStockNumberAndDeletedFalse(String stockNumber);
 }

--- a/src/main/java/com/testcar/car/domains/carStock/repository/CarStockRepository.java
+++ b/src/main/java/com/testcar/car/domains/carStock/repository/CarStockRepository.java
@@ -2,12 +2,13 @@ package com.testcar.car.domains.carStock.repository;
 
 
 import com.testcar.car.domains.carStock.entity.CarStock;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CarStockRepository
         extends JpaRepository<CarStock, Long>, CarStockCustomRepository {
     Optional<CarStock> findByIdAndDeletedFalse(Long id);
-
+    List<CarStock> findAllByIdInAndDeletedFalse(List<Long> ids);
     boolean existsByStockNumberAndDeletedFalse(String stockNumber);
 }

--- a/src/main/java/com/testcar/car/domains/member/Member.java
+++ b/src/main/java/com/testcar/car/domains/member/Member.java
@@ -63,7 +63,6 @@ public class Member extends BaseEntity {
     public Member update(Member member) {
         this.department = member.getDepartment();
         this.email = member.getEmail();
-        this.password = member.getPassword();
         this.name = member.getName();
         this.role = member.getRole();
         return this;

--- a/src/main/java/com/testcar/car/domains/member/MemberController.java
+++ b/src/main/java/com/testcar/car/domains/member/MemberController.java
@@ -6,6 +6,7 @@ import com.testcar.car.common.annotation.RoleAllowed;
 import com.testcar.car.common.response.PageResponse;
 import com.testcar.car.domains.member.model.MemberResponse;
 import com.testcar.car.domains.member.model.RegisterMemberRequest;
+import com.testcar.car.domains.member.model.UpdateMemberRequest;
 import com.testcar.car.domains.member.model.vo.MemberFilterCondition;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -66,7 +67,7 @@ public class MemberController {
     @RoleAllowed(role = Role.ADMIN)
     @Operation(summary = "[사용자 관리] 사용자 정보 수정", description = "(관리자) 사용자 정보를 수정합니다.")
     public MemberResponse update(
-            @PathVariable Long memberId, @Valid @RequestBody RegisterMemberRequest request) {
+            @PathVariable Long memberId, @Valid @RequestBody UpdateMemberRequest request) {
         final Member member = memberService.updateById(memberId, request);
         return MemberResponse.from(member);
     }
@@ -74,8 +75,8 @@ public class MemberController {
     @DeleteMapping("/{memberId}")
     @RoleAllowed(role = Role.ADMIN)
     @Operation(summary = "[사용자 관리] 사용자 삭제", description = "(관리자) 사용자를 삭제합니다.")
-    public MemberResponse withdraw(@PathVariable Long memberId) {
-        final Member member = memberService.deleteById(memberId);
-        return MemberResponse.from(member);
+    public MemberResponse withdraw(@AuthMember Member member, @PathVariable Long memberId) {
+        final Member deleteMember = memberService.deleteById(member, memberId);
+        return MemberResponse.from(deleteMember);
     }
 }

--- a/src/main/java/com/testcar/car/domains/member/exception/ErrorCode.java
+++ b/src/main/java/com/testcar/car/domains/member/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode implements BaseErrorCode {
     MEMBER_NOT_FOUND("MEM001", "해당 사용자를 찾을 수 없습니다."),
     INVALID_PASSWORD("MEM002", "잘못된 비밀번호 입니다."),
     UNAUTHORIZED_USER("MEM003", "해당 기능에 대한 접근 권한이 없습니다."),
-    DUPLICATED_EMAIL("MEM004", "중복된 이메일 입니다.");
+    DUPLICATED_EMAIL("MEM004", "중복된 이메일 입니다."),
+    CANNOT_DELETE_MYSELF("MEM005", "자신의 계정은 삭제할 수 없습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/testcar/car/domains/member/model/UpdateMemberRequest.java
+++ b/src/main/java/com/testcar/car/domains/member/model/UpdateMemberRequest.java
@@ -1,0 +1,33 @@
+package com.testcar.car.domains.member.model;
+
+
+import com.testcar.car.domains.member.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+public class UpdateMemberRequest {
+    @NotNull
+    @Positive
+    @Schema(description = "부서 ID", example = "1")
+    private Long departmentId;
+
+    @Email
+    @NotBlank
+    @Length(max = 50)
+    @Schema(description = "이메일", example = "kls1998@naver.com")
+    private String email;
+
+    @NotBlank
+    @Schema(description = "이름", example = "홍길동")
+    private String name;
+
+    @NotNull
+    @Schema(description = "권한", example = "USER", implementation = Role.class)
+    private Role role;
+}

--- a/src/main/resources/db/migration/V7__UpdateCarStock.sql
+++ b/src/main/resources/db/migration/V7__UpdateCarStock.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `CarStock`
+    MODIFY COLUMN `status` VARCHAR(20) NOT NULL COMMENT '차량 재고 상태';


### PR DESCRIPTION
- 프론트와 연동하며 발생한 오류를 해결했습니다.
- 사용자 및 차량 업데이트, 생성시 중복 메세지 오류를 수정했습니다.
- enum status 의 길이 제한으로 인한 쿼리 오류를 수정했습니다.
- querydsl 조회 시 id == null 인 경우에 대한 분기 처리를 추가했습니다.