### PR TITLE
test: 시험장 관리 단위 테스트 구현

### DIFF
--- a/src/main/java/com/testcar/car/domains/gasStationHistory/repository/GasStationHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/testcar/car/domains/gasStationHistory/repository/GasStationHistoryCustomRepositoryImpl.java
@@ -50,10 +50,10 @@ public class GasStationHistoryCustomRepositoryImpl
 
         final List<GasStationHistoryDto> result =
                 queryGasStationHistoryDto()
+                        .where(gasStationHistory.id.in(coveringIndex))
                         .orderBy(
                                 gasStationHistory.usedAt.desc(),
                                 gasStationHistory.gasStation.name.asc())
-                        .where(gasStationHistory.id.in(coveringIndex))
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize())
                         .fetch();

--- a/src/main/java/com/testcar/car/domains/trackReservation/TrackReservationService.java
+++ b/src/main/java/com/testcar/car/domains/trackReservation/TrackReservationService.java
@@ -50,17 +50,18 @@ public class TrackReservationService {
     /** 해당 시험장을 예약합니다. */
     public TrackReservation reserve(Member member, Long trackId, TrackReservationRequest request) {
         final Track track = trackService.findById(trackId);
-        final TrackReservation trackReservation = this.createEntity(member, track);
-        trackReservationRepository.save(trackReservation);
+        final TrackReservation trackReservation =
+                trackReservationRepository.save(this.createEntity(member, track));
         trackReservationSlotService.reserve(track, trackReservation, request);
         return trackReservation;
     }
 
+    /** 시험장 예약을 취소하거나 반납한다 */
     public TrackReservation cancel(Member member, Long trackReservationId) {
         final TrackReservation trackReservation =
                 this.findByMemberAndId(member, trackReservationId);
 
-        if (trackReservation.getStatus() == ReservationStatus.CANCELED) {
+        if (!trackReservation.isCancelable()) {
             throw new BadRequestException(RESERVATION_ALREADY_CANCELED);
         }
         trackReservation.cancel();

--- a/src/main/java/com/testcar/car/domains/trackReservation/entity/TrackReservation.java
+++ b/src/main/java/com/testcar/car/domains/trackReservation/entity/TrackReservation.java
@@ -62,4 +62,8 @@ public class TrackReservation extends BaseEntity {
     public void cancel() {
         this.status = ReservationStatus.CANCELED;
     }
+
+    public boolean isCancelable() {
+        return this.status == ReservationStatus.RESERVED || this.status == ReservationStatus.USING;
+    }
 }

--- a/src/test/java/com/testcar/car/common/Constant.java
+++ b/src/test/java/com/testcar/car/common/Constant.java
@@ -3,10 +3,18 @@ package com.testcar.car.common;
 
 import com.testcar.car.domains.car.entity.Type;
 import com.testcar.car.domains.member.Role;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public class Constant {
     private Constant() {}
+
+    /** Date */
+    public static final LocalDateTime NOW =
+            LocalDateTime.now().withHour(12).withMinute(0).withSecond(0).withNano(0);
+
+    public static final LocalDateTime TOMORROW = NOW.plusDays(1L);
+    public static final LocalDateTime YESTERDAY = NOW.minusDays(1L);
 
     /** Member */
     public static final String MEMBER_EMAIL = "test@test.com";
@@ -24,8 +32,8 @@ public class Constant {
     public static final Type CAR_TYPE = Type.SEDAN;
     public static final String CAR_STOCK_NUMBER = "123456789012";
     public static final String ANOTHER_CAR_STOCK_NUMBER = "987654321098";
-    public static final LocalDateTime STARTED_AT = LocalDateTime.of(2021, 1, 1, 0, 0, 0);
-    public static final LocalDateTime EXPIRED_AT = LocalDateTime.of(2021, 1, 8, 0, 0, 0);
+    public static final LocalDateTime STARTED_AT = NOW;
+    public static final LocalDateTime EXPIRED_AT = NOW.plusDays(7L);
     public static final String CAR_TEST_RESULT = "통과";
 
     /** Track */
@@ -35,4 +43,7 @@ public class Constant {
     public static final String TRACK_LOCATION = "서산주행시험장";
     public static final String TRACK_DESCRIPTION = "비탈길";
     public static final double TRACK_LENGTH = 1230.6;
+    public static final LocalDate TRACK_RESERVATION_DATE = TOMORROW.toLocalDate();
+    public static final LocalDateTime TRACK_RESERVATION_SLOT_STARTED_AT = TOMORROW.withHour(11);
+    public static final LocalDateTime TRACK_RESERVATION_SLOT_EXPIRED_AT = TOMORROW.withHour(12);
 }

--- a/src/test/java/com/testcar/car/common/Constant.java
+++ b/src/test/java/com/testcar/car/common/Constant.java
@@ -29,10 +29,10 @@ public class Constant {
     public static final String CAR_TEST_RESULT = "통과";
 
     /** Track */
-    public static final String TRACK_NAME = "서산주행시험장";
+    public static final String TRACK_NAME = "고속주행로";
 
-    public static final String ANOTHER_TRACK_NAME = "마포주행시험장";
-    public static final String TRACK_LOCATION = "충청남도 서산시 부석면";
+    public static final String ANOTHER_TRACK_NAME = "경사로";
+    public static final String TRACK_LOCATION = "서산주행시험장";
     public static final String TRACK_DESCRIPTION = "비탈길";
-    public static final double TRACK_LENGTH = 12.6;
+    public static final double TRACK_LENGTH = 1230.6;
 }

--- a/src/test/java/com/testcar/car/common/TrackEntityFactory.java
+++ b/src/test/java/com/testcar/car/common/TrackEntityFactory.java
@@ -4,12 +4,16 @@ import static com.testcar.car.common.Constant.TRACK_DESCRIPTION;
 import static com.testcar.car.common.Constant.TRACK_LENGTH;
 import static com.testcar.car.common.Constant.TRACK_LOCATION;
 import static com.testcar.car.common.Constant.TRACK_NAME;
+import static com.testcar.car.common.Constant.TRACK_RESERVATION_SLOT_EXPIRED_AT;
+import static com.testcar.car.common.Constant.TRACK_RESERVATION_SLOT_STARTED_AT;
 
 import com.testcar.car.domains.track.Track;
 import com.testcar.car.domains.track.Track.TrackBuilder;
 import com.testcar.car.domains.trackReservation.entity.ReservationStatus;
 import com.testcar.car.domains.trackReservation.entity.TrackReservation;
 import com.testcar.car.domains.trackReservation.entity.TrackReservation.TrackReservationBuilder;
+import com.testcar.car.domains.trackReservation.entity.TrackReservationSlot;
+import java.util.Set;
 
 public class TrackEntityFactory {
     private TrackEntityFactory() {}
@@ -35,5 +39,28 @@ public class TrackEntityFactory {
                 .member(MemberEntityFactory.createMember())
                 .track(createTrack())
                 .status(ReservationStatus.RESERVED);
+    }
+
+    public static TrackReservationSlot createTrackReservationSlot() {
+        return createTrackReservationSlotBuilder().build();
+    }
+
+    public static TrackReservationSlot createTrackReservationSlot(
+            TrackReservation trackReservation) {
+        return createTrackReservationSlotBuilder()
+                .trackReservation(trackReservation)
+                .startedAt(TRACK_RESERVATION_SLOT_STARTED_AT)
+                .expiredAt(TRACK_RESERVATION_SLOT_EXPIRED_AT)
+                .build();
+    }
+
+    public static TrackReservationSlot.TrackReservationSlotBuilder
+            createTrackReservationSlotBuilder() {
+        return TrackReservationSlot.builder().trackReservation(createTrackReservation());
+    }
+
+    public static Set<TrackReservationSlot> createTrackReservationSlotSet() {
+        final TrackReservation trackReservation = createTrackReservation();
+        return Set.of(createTrackReservationSlot(trackReservation));
     }
 }

--- a/src/test/java/com/testcar/car/common/TrackEntityFactory.java
+++ b/src/test/java/com/testcar/car/common/TrackEntityFactory.java
@@ -7,6 +7,9 @@ import static com.testcar.car.common.Constant.TRACK_NAME;
 
 import com.testcar.car.domains.track.Track;
 import com.testcar.car.domains.track.Track.TrackBuilder;
+import com.testcar.car.domains.trackReservation.entity.ReservationStatus;
+import com.testcar.car.domains.trackReservation.entity.TrackReservation;
+import com.testcar.car.domains.trackReservation.entity.TrackReservation.TrackReservationBuilder;
 
 public class TrackEntityFactory {
     private TrackEntityFactory() {}
@@ -21,5 +24,16 @@ public class TrackEntityFactory {
                 .location(TRACK_LOCATION)
                 .description(TRACK_DESCRIPTION)
                 .length(TRACK_LENGTH);
+    }
+
+    public static TrackReservation createTrackReservation() {
+        return createTrackReservationBuilder().build();
+    }
+
+    public static TrackReservationBuilder createTrackReservationBuilder() {
+        return TrackReservation.builder()
+                .member(MemberEntityFactory.createMember())
+                .track(createTrack())
+                .status(ReservationStatus.RESERVED);
     }
 }

--- a/src/test/java/com/testcar/car/domains/track/TrackServiceTest.java
+++ b/src/test/java/com/testcar/car/domains/track/TrackServiceTest.java
@@ -1,0 +1,225 @@
+package com.testcar.car.domains.track;
+
+import static com.testcar.car.common.Constant.ANOTHER_TRACK_NAME;
+import static com.testcar.car.common.Constant.TRACK_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.testcar.car.common.TrackEntityFactory;
+import com.testcar.car.common.exception.BadRequestException;
+import com.testcar.car.common.exception.NotFoundException;
+import com.testcar.car.domains.track.model.DeleteTrackRequest;
+import com.testcar.car.domains.track.model.RegisterTrackRequest;
+import com.testcar.car.domains.track.model.vo.TrackFilterCondition;
+import com.testcar.car.domains.track.repository.TrackRepository;
+import com.testcar.car.domains.track.request.TrackRequestFactory;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TrackServiceTest {
+    @Mock private TrackRepository trackRepository;
+
+    @InjectMocks private TrackService trackService;
+
+    private static Track track;
+    private static final Long trackId = 1L;
+    private static List<Track> tracks;
+    private static final List<Long> trackIds = List.of(1L, 2L);
+    private static final String trackName = TRACK_NAME;
+
+    @BeforeAll
+    public static void setUp() {
+        track = TrackEntityFactory.createTrack();
+        tracks = List.of(TrackEntityFactory.createTrack(), TrackEntityFactory.createTrack());
+    }
+
+    @Test
+    void 시험장_ID로_시험장_엔티티를_가져온다() {
+        // given
+        when(trackRepository.findByIdAndDeletedFalse(trackId)).thenReturn(Optional.of(track));
+
+        // when
+        final Track result = trackService.findById(trackId);
+
+        // then
+        assertEquals(track, result);
+        verify(trackRepository).findByIdAndDeletedFalse(trackId);
+    }
+
+    @Test
+    void 시험장_ID가_포함된_시험장이_DB에_존재하지_않으면_오류가_발생한다() {
+        // given
+        when(trackRepository.findByIdAndDeletedFalse(trackId)).thenReturn(Optional.empty());
+
+        // when, then
+        Assertions.assertThrows(
+                NotFoundException.class,
+                () -> {
+                    trackService.findById(trackId);
+                });
+    }
+
+    @Test
+    void 시험장_이름으로_시험장_엔티티를_가져온다() {
+        // given
+        when(trackRepository.findByNameAndDeletedFalse(trackName)).thenReturn(Optional.of(track));
+
+        // when
+        final Track result = trackService.findByName(trackName);
+
+        // then
+        assertEquals(track, result);
+        verify(trackRepository).findByNameAndDeletedFalse(trackName);
+    }
+
+    @Test
+    void 시험장_이름이_포함된_시험장이_DB에_존재하지_않으면_오류가_발생한다() {
+        // given
+        when(trackRepository.findByNameAndDeletedFalse(trackName)).thenReturn(Optional.empty());
+
+        // when, then
+        Assertions.assertThrows(
+                NotFoundException.class,
+                () -> {
+                    trackService.findByName(trackName);
+                });
+    }
+
+    @Test
+    void 시험장_id_리스트로_시험장_리스트를_가져온다() {
+        // given
+        when(trackRepository.findAllByIdInAndDeletedFalse(trackIds)).thenReturn(tracks);
+
+        // when
+        final List<Track> result = trackService.findAllByIdIn(trackIds);
+
+        // then
+        assertEquals(tracks, result);
+        verify(trackRepository).findAllByIdInAndDeletedFalse(trackIds);
+    }
+
+    @Test
+    void 시험장_id_리스트와_시험장_리스트의_결과_개수가_다르면_오류가_발생한다() {
+        // given
+        when(trackRepository.findAllByIdInAndDeletedFalse(trackIds)).thenReturn(List.of(track));
+
+        // when
+        Assertions.assertThrows(
+                NotFoundException.class,
+                () -> {
+                    trackService.findAllByIdIn(trackIds);
+                });
+
+        // then
+        verify(trackRepository).findAllByIdInAndDeletedFalse(trackIds);
+    }
+
+    @Test
+    void 조건에_맞는_시험장_리스트를_가져온다() {
+        // given
+        final TrackFilterCondition condition = new TrackFilterCondition();
+        when(trackRepository.findAllByCondition(condition)).thenReturn(tracks);
+
+        // when
+        final List<Track> result = trackService.findAllByCondition(condition);
+
+        // then
+        assertEquals(tracks, result);
+        verify(trackRepository).findAllByCondition(condition);
+    }
+
+    @Test
+    void 시험장을_등록한다() {
+        // given
+        final RegisterTrackRequest request = TrackRequestFactory.createRegisterTrackRequest();
+        when(trackRepository.save(any(Track.class))).thenReturn(track);
+
+        // when
+        final Track result = trackService.register(request);
+
+        // then
+        assertEquals(track, result);
+        verify(trackRepository).save(any(Track.class));
+    }
+
+    @Test
+    void DB에_존재하는_시험장_이름과_같으면_등록할수_없다() {
+        // given
+        final RegisterTrackRequest request = TrackRequestFactory.createRegisterTrackRequest();
+        when(trackRepository.existsByNameAndDeletedFalse(request.getName())).thenReturn(true);
+
+        // when
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> {
+                    trackService.register(request);
+                });
+
+        // then
+        then(trackRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void 시험장_정보를_수정한다() {
+        // given
+        final RegisterTrackRequest request =
+                TrackRequestFactory.createRegisterTrackRequest(ANOTHER_TRACK_NAME);
+        when(trackRepository.findByIdAndDeletedFalse(trackId)).thenReturn(Optional.of(track));
+        when(trackRepository.existsByNameAndDeletedFalse(request.getName())).thenReturn(false);
+        when(trackRepository.save(any(Track.class))).thenReturn(track);
+
+        // when
+        final Track result = trackService.updateById(trackId, request);
+
+        // then
+        assertEquals(track, result);
+        verify(trackRepository).findByIdAndDeletedFalse(trackId);
+        verify(trackRepository).existsByNameAndDeletedFalse(request.getName());
+        verify(trackRepository).save(any(Track.class));
+    }
+
+    @Test
+    void DB에_이미_존재하는_이름의_시험장으로_수정할수_없다() {
+        // given
+        final RegisterTrackRequest request =
+                TrackRequestFactory.createRegisterTrackRequest(ANOTHER_TRACK_NAME);
+        when(trackRepository.findByIdAndDeletedFalse(trackId)).thenReturn(Optional.of(track));
+        when(trackRepository.existsByNameAndDeletedFalse(request.getName())).thenReturn(true);
+
+        // when
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> {
+                    trackService.updateById(trackId, request);
+                });
+
+        // then
+        verify(trackRepository).findByIdAndDeletedFalse(trackId);
+        then(trackRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void 시험장ID_리스트로_시험장을_모두_삭제한다() {
+        // given
+        final DeleteTrackRequest request = TrackRequestFactory.createDeleteTrackRequest(trackIds);
+        when(trackRepository.findAllByIdInAndDeletedFalse(trackIds)).thenReturn(tracks);
+
+        // when
+        final List<Long> result = trackService.deleteAll(request);
+
+        // then
+        assertEquals(trackIds, result);
+        verify(trackRepository).findAllByIdInAndDeletedFalse(trackIds);
+    }
+}

--- a/src/test/java/com/testcar/car/domains/track/entity/TrackTest.java
+++ b/src/test/java/com/testcar/car/domains/track/entity/TrackTest.java
@@ -1,0 +1,59 @@
+package com.testcar.car.domains.track.entity;
+
+import static com.testcar.car.common.Constant.TRACK_DESCRIPTION;
+import static com.testcar.car.common.Constant.TRACK_LENGTH;
+import static com.testcar.car.common.Constant.TRACK_LOCATION;
+import static com.testcar.car.common.Constant.TRACK_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.testcar.car.common.TrackEntityFactory;
+import com.testcar.car.domains.track.Track;
+import org.junit.jupiter.api.Test;
+
+public class TrackTest {
+    @Test
+    public void 시험장_엔티티를_생성한다() {
+        // given
+        final String name = TRACK_NAME;
+        final String location = TRACK_LOCATION;
+        final String description = TRACK_DESCRIPTION;
+        final Double length = TRACK_LENGTH;
+
+        // when
+        final Track track =
+                Track.builder()
+                        .name(name)
+                        .location(location)
+                        .description(description)
+                        .length(length)
+                        .build();
+
+        // then
+        assertThat(track.getName()).isEqualTo(name);
+        assertThat(track.getLocation()).isEqualTo(location);
+        assertThat(track.getDescription()).isEqualTo(description);
+        assertThat(track.getLength()).isEqualTo(length);
+    }
+
+    @Test
+    public void 시험장_정보를_변경한다() {
+        // given
+        final Track track = TrackEntityFactory.createTrack();
+        final Track updateTrack =
+                Track.builder()
+                        .name("급선회로")
+                        .location("서울주행시험장")
+                        .description("급경사")
+                        .length(700.0)
+                        .build();
+
+        // when
+        track.update(updateTrack);
+
+        // then
+        assertThat(track.getName()).isEqualTo(updateTrack.getName());
+        assertThat(track.getLocation()).isEqualTo(updateTrack.getLocation());
+        assertThat(track.getDescription()).isEqualTo(updateTrack.getDescription());
+        assertThat(track.getLength()).isEqualTo(updateTrack.getLength());
+    }
+}

--- a/src/test/java/com/testcar/car/domains/track/request/TrackRequestFactory.java
+++ b/src/test/java/com/testcar/car/domains/track/request/TrackRequestFactory.java
@@ -21,6 +21,15 @@ public class TrackRequestFactory {
                 .build();
     }
 
+    public static RegisterTrackRequest createRegisterTrackRequest(String name) {
+        return RegisterTrackRequest.builder()
+                .name(name)
+                .location(TRACK_LOCATION)
+                .description(TRACK_DESCRIPTION)
+                .length(TRACK_LENGTH)
+                .build();
+    }
+
     public static DeleteTrackRequest createDeleteTrackRequest(List<Long> ids) {
         return DeleteTrackRequest.builder().ids(ids).build();
     }

--- a/src/test/java/com/testcar/car/domains/track/request/TrackRequestFactory.java
+++ b/src/test/java/com/testcar/car/domains/track/request/TrackRequestFactory.java
@@ -1,12 +1,17 @@
 package com.testcar.car.domains.track.request;
 
+import static com.testcar.car.common.Constant.TOMORROW;
 import static com.testcar.car.common.Constant.TRACK_DESCRIPTION;
 import static com.testcar.car.common.Constant.TRACK_LENGTH;
 import static com.testcar.car.common.Constant.TRACK_LOCATION;
 import static com.testcar.car.common.Constant.TRACK_NAME;
+import static com.testcar.car.common.Constant.TRACK_RESERVATION_DATE;
+import static com.testcar.car.common.Constant.YESTERDAY;
 
 import com.testcar.car.domains.track.model.DeleteTrackRequest;
 import com.testcar.car.domains.track.model.RegisterTrackRequest;
+import com.testcar.car.domains.trackReservation.model.TrackReservationRequest;
+import com.testcar.car.domains.trackReservation.model.vo.ReservationSlotVo;
 import java.util.List;
 
 public class TrackRequestFactory {
@@ -32,5 +37,35 @@ public class TrackRequestFactory {
 
     public static DeleteTrackRequest createDeleteTrackRequest(List<Long> ids) {
         return DeleteTrackRequest.builder().ids(ids).build();
+    }
+
+    private static List<ReservationSlotVo> createReservationSlotVoList() {
+        return List.of(createReservationSlotVo(11), createReservationSlotVo(12));
+    }
+
+    public static TrackReservationRequest createTrackReservationRequest() {
+        return TrackReservationRequest.builder()
+                .date(TRACK_RESERVATION_DATE)
+                .reservationSlots(createReservationSlotVoList())
+                .build();
+    }
+
+    public static TrackReservationRequest createInvalidTrackReservationRequest() {
+        return TrackReservationRequest.builder()
+                .date(TRACK_RESERVATION_DATE)
+                .reservationSlots(
+                        List.of(
+                                ReservationSlotVo.builder()
+                                        .startedAt(YESTERDAY.withHour(12))
+                                        .expiredAt(YESTERDAY.withHour(13))
+                                        .build()))
+                .build();
+    }
+
+    private static ReservationSlotVo createReservationSlotVo(int hour) {
+        return ReservationSlotVo.builder()
+                .startedAt(TOMORROW.withHour(hour))
+                .expiredAt(TOMORROW.withHour(hour + 1))
+                .build();
     }
 }

--- a/src/test/java/com/testcar/car/domains/track/request/TrackRequestFactory.java
+++ b/src/test/java/com/testcar/car/domains/track/request/TrackRequestFactory.java
@@ -1,0 +1,27 @@
+package com.testcar.car.domains.track.request;
+
+import static com.testcar.car.common.Constant.TRACK_DESCRIPTION;
+import static com.testcar.car.common.Constant.TRACK_LENGTH;
+import static com.testcar.car.common.Constant.TRACK_LOCATION;
+import static com.testcar.car.common.Constant.TRACK_NAME;
+
+import com.testcar.car.domains.track.model.DeleteTrackRequest;
+import com.testcar.car.domains.track.model.RegisterTrackRequest;
+import java.util.List;
+
+public class TrackRequestFactory {
+    private TrackRequestFactory() {}
+
+    public static RegisterTrackRequest createRegisterTrackRequest() {
+        return RegisterTrackRequest.builder()
+                .name(TRACK_NAME)
+                .location(TRACK_LOCATION)
+                .description(TRACK_DESCRIPTION)
+                .length(TRACK_LENGTH)
+                .build();
+    }
+
+    public static DeleteTrackRequest createDeleteTrackRequest(List<Long> ids) {
+        return DeleteTrackRequest.builder().ids(ids).build();
+    }
+}

--- a/src/test/java/com/testcar/car/domains/trackReservation/TrackReservationServiceTest.java
+++ b/src/test/java/com/testcar/car/domains/trackReservation/TrackReservationServiceTest.java
@@ -1,0 +1,182 @@
+package com.testcar.car.domains.trackReservation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.testcar.car.common.MemberEntityFactory;
+import com.testcar.car.common.TrackEntityFactory;
+import com.testcar.car.common.exception.BadRequestException;
+import com.testcar.car.common.exception.NotFoundException;
+import com.testcar.car.domains.member.Member;
+import com.testcar.car.domains.track.Track;
+import com.testcar.car.domains.track.TrackService;
+import com.testcar.car.domains.track.request.TrackRequestFactory;
+import com.testcar.car.domains.trackReservation.entity.ReservationStatus;
+import com.testcar.car.domains.trackReservation.entity.TrackReservation;
+import com.testcar.car.domains.trackReservation.entity.TrackReservationSlot;
+import com.testcar.car.domains.trackReservation.model.TrackReservationRequest;
+import com.testcar.car.domains.trackReservation.model.vo.TrackReservationFilterCondition;
+import com.testcar.car.domains.trackReservation.repository.TrackReservationRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TrackReservationServiceTest {
+    @Mock private TrackReservationRepository trackReservationRepository;
+    @Mock private TrackService trackService;
+    @Mock private TrackReservationSlotService trackReservationSlotService;
+    @InjectMocks private TrackReservationService trackReservationService;
+
+    private static Member member;
+    private static Track track;
+    private static TrackReservation trackReservation;
+    private static List<TrackReservation> trackReservations;
+    private static Set<TrackReservationSlot> trackReservationSlots;
+    private static final Long trackReservationId = 1L;
+
+    @BeforeAll
+    public static void setUp() {
+        member = MemberEntityFactory.createMember();
+        track = TrackEntityFactory.createTrack();
+        trackReservation = TrackEntityFactory.createTrackReservation();
+        trackReservations =
+                List.of(
+                        TrackEntityFactory.createTrackReservation(),
+                        TrackEntityFactory.createTrackReservation());
+        trackReservationSlots = TrackEntityFactory.createTrackReservationSlotSet();
+    }
+
+    @Test
+    void 사용자와_시험장_예약_ID로_엔티티를_가져온다() {
+        // given
+        when(trackReservationRepository.findByMemberIdAndId(member.getId(), trackReservationId))
+                .thenReturn(Optional.of(trackReservation));
+
+        // when
+        final TrackReservation result =
+                trackReservationService.findByMemberAndId(member, trackReservationId);
+
+        // then
+        assertEquals(trackReservation, result);
+        verify(trackReservationRepository).findByMemberIdAndId(member.getId(), trackReservationId);
+    }
+
+    @Test
+    void 시험장예약_ID가_포함된_정보가_DB에_존재하지_않으면_오류가_발생한다() {
+        // given
+        when(trackReservationRepository.findByMemberIdAndId(member.getId(), trackReservationId))
+                .thenReturn(Optional.empty());
+
+        // when, then
+        Assertions.assertThrows(
+                NotFoundException.class,
+                () -> {
+                    trackReservationService.findByMemberAndId(member, trackReservationId);
+                });
+    }
+
+    @Test
+    void 조건에_맞는_시험장예약_리스트를_가져온다() {
+        // given
+        final TrackReservationFilterCondition condition = new TrackReservationFilterCondition();
+        when(trackReservationRepository.findAllByMemberIdAndCondition(member.getId(), condition))
+                .thenReturn(trackReservations);
+
+        // when
+        final List<TrackReservation> result =
+                trackReservationService.findAllByMemberAndCondition(member, condition);
+
+        // then
+        assertEquals(trackReservations, result);
+        verify(trackReservationRepository).findAllByMemberIdAndCondition(member.getId(), condition);
+    }
+
+    @Test
+    void 시험장의_특정_일자의_모든_예약슬롯을_조회한다() {
+        // given
+        final LocalDate date = LocalDate.now();
+        when(trackReservationSlotService.findAllByTrackIdAndDate(track.getId(), date))
+                .thenReturn(trackReservationSlots);
+
+        // when
+        final Set<TrackReservationSlot> result =
+                trackReservationService.findUnavailableReservationSlots(track.getId(), date);
+
+        // then
+        assertEquals(trackReservationSlots, result);
+        verify(trackReservationSlotService).findAllByTrackIdAndDate(track.getId(), date);
+    }
+
+    @Test
+    void 시험장을_예약한다() {
+        // given
+        final TrackReservationRequest request = TrackRequestFactory.createTrackReservationRequest();
+        when(trackService.findById(track.getId())).thenReturn(track);
+        when(trackReservationRepository.save(any(TrackReservation.class)))
+                .thenReturn(trackReservation);
+
+        // when
+        final TrackReservation result =
+                trackReservationService.reserve(member, track.getId(), request);
+
+        // then
+        assertEquals(trackReservation, result);
+        verify(trackService).findById(track.getId());
+        verify(trackReservationRepository).save(any(TrackReservation.class));
+        verify(trackReservationSlotService).reserve(track, trackReservation, request);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ReservationStatus.class,
+            names = {"RESERVED", "USING"})
+    void 시험장_예약을_취소_또는_반납한다(ReservationStatus status) {
+        // given
+        final TrackReservation cancelableTrackReservation =
+                TrackEntityFactory.createTrackReservationBuilder().status(status).build();
+        when(trackReservationRepository.findByMemberIdAndId(member.getId(), trackReservationId))
+                .thenReturn(Optional.of(cancelableTrackReservation));
+        when(trackReservationRepository.save(cancelableTrackReservation))
+                .thenReturn(cancelableTrackReservation);
+
+        // when
+        final TrackReservation result = trackReservationService.cancel(member, trackReservationId);
+
+        // then
+        assertEquals(cancelableTrackReservation, result);
+        verify(trackReservationRepository).findByMemberIdAndId(member.getId(), trackReservationId);
+        verify(trackReservationRepository).save(cancelableTrackReservation);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ReservationStatus.class,
+            names = {"CANCELED", "COMPLETED"})
+    void 시험장을_반납했거나_이용완료_상태면_반납할수_없다(ReservationStatus status) {
+        // given
+        final TrackReservation notCancelableTrackReservation =
+                TrackEntityFactory.createTrackReservationBuilder().status(status).build();
+        when(trackReservationRepository.findByMemberIdAndId(member.getId(), trackReservationId))
+                .thenReturn(Optional.of(notCancelableTrackReservation));
+
+        // when, then
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> {
+                    trackReservationService.cancel(member, trackReservationId);
+                });
+    }
+}

--- a/src/test/java/com/testcar/car/domains/trackReservation/TrackReservationSlotServiceTest.java
+++ b/src/test/java/com/testcar/car/domains/trackReservation/TrackReservationSlotServiceTest.java
@@ -1,0 +1,127 @@
+package com.testcar.car.domains.trackReservation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.testcar.car.common.TrackEntityFactory;
+import com.testcar.car.common.exception.BadRequestException;
+import com.testcar.car.domains.track.Track;
+import com.testcar.car.domains.track.request.TrackRequestFactory;
+import com.testcar.car.domains.trackReservation.entity.TrackReservation;
+import com.testcar.car.domains.trackReservation.entity.TrackReservationSlot;
+import com.testcar.car.domains.trackReservation.model.TrackReservationRequest;
+import com.testcar.car.domains.trackReservation.repository.TrackReservationSlotRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TrackReservationSlotServiceTest {
+    @Mock private TrackReservationSlotRepository trackReservationSlotRepository;
+    @InjectMocks private TrackReservationSlotService trackReservationSlotService;
+
+    private static Track track;
+    private static TrackReservation trackReservation;
+    private static Set<TrackReservationSlot> trackReservationSlots;
+    private static final Long trackReservationId = 1L;
+
+    @BeforeAll
+    public static void setUp() {
+        track = TrackEntityFactory.createTrack();
+        trackReservation = TrackEntityFactory.createTrackReservation();
+        trackReservationSlots = TrackEntityFactory.createTrackReservationSlotSet();
+    }
+
+    @Test
+    void 시험장_ID와_날짜로_해당날짜에_시험장에_예약된_모든_슬롯_엔티티를_가져온다() {
+        // given
+        final LocalDate date = LocalDate.now();
+        when(trackReservationSlotRepository.findAllByTrackIdAndDate(track.getId(), date))
+                .thenReturn(trackReservationSlots);
+
+        // when
+        final Set<TrackReservationSlot> result =
+                trackReservationSlotService.findAllByTrackIdAndDate(track.getId(), date);
+
+        // then
+        assertEquals(trackReservationSlots, result);
+        verify(trackReservationSlotRepository).findAllByTrackIdAndDate(track.getId(), date);
+    }
+
+    @Test
+    void 시험장_정보로_해당_시험장의_예약_슬롯을_할당하고_DB에_저장한다() {
+        // given
+        final TrackReservationRequest request = TrackRequestFactory.createTrackReservationRequest();
+        final List<TrackReservationSlot> trackReservationSlots =
+                List.of(TrackEntityFactory.createTrackReservationSlot());
+        when(trackReservationSlotRepository.saveAll(anyCollection()))
+                .thenReturn(trackReservationSlots);
+
+        // when
+        trackReservationSlotService.reserve(track, trackReservation, request);
+
+        // then
+        verify(trackReservationSlotRepository).saveAll(anyCollection());
+    }
+
+    @Test
+    void 예약요청시간과_마감시간이_현재시간보다_이전이면_시험장을_예약할수_없다() {
+        // given
+        final TrackReservationRequest request =
+                TrackRequestFactory.createInvalidTrackReservationRequest();
+
+        // when, then
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> {
+                    trackReservationSlotService.reserve(track, trackReservation, request);
+                });
+        then(trackReservationSlotRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void 시험장의_이미_예약된_시간에는_예약할수_없다() {
+        // given
+        final TrackReservationRequest request = TrackRequestFactory.createTrackReservationRequest();
+        when(trackReservationSlotRepository.findAllByTrackIdAndDate(
+                        track.getId(), request.getDate()))
+                .thenReturn(trackReservationSlots);
+
+        // when, then
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> {
+                    trackReservationSlotService.reserve(track, trackReservation, request);
+                });
+        then(trackReservationSlotRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void 시험장_예약_ID로_예약_슬롯을_모두_취소한다() {
+        // given
+        when(trackReservationSlotRepository.findAllByTrackReservationId(trackReservationId))
+                .thenReturn(trackReservationSlots);
+        when(trackReservationSlotRepository.saveAll(anyCollection()))
+                .thenReturn(trackReservationSlots.stream().toList());
+
+        // when
+        List<TrackReservationSlot> deletedTrackReservationSlots =
+                trackReservationSlotService.cancelByTrackReservationId(trackReservationId);
+
+        // then
+        verify(trackReservationSlotRepository).findAllByTrackReservationId(trackReservationId);
+        verify(trackReservationSlotRepository).saveAll(anyCollection());
+        deletedTrackReservationSlots.forEach(slot -> assertTrue(slot.getDeleted()));
+    }
+}

--- a/src/test/java/com/testcar/car/domains/trackReservation/entity/TrackReservationSlotTest.java
+++ b/src/test/java/com/testcar/car/domains/trackReservation/entity/TrackReservationSlotTest.java
@@ -1,0 +1,34 @@
+package com.testcar.car.domains.trackReservation.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.testcar.car.common.TrackEntityFactory;
+import com.testcar.car.domains.track.Track;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+public class TrackReservationSlotTest {
+    @Test
+    public void 시험장_예약시간_슬롯_엔티티를_생성한다() {
+        // given
+        final Track track = TrackEntityFactory.createTrack();
+        final TrackReservation trackReservation = TrackEntityFactory.createTrackReservation();
+        final LocalDateTime startedAt = LocalDateTime.now();
+        final LocalDateTime expiredAt = startedAt.plusHours(1L);
+
+        // when
+        final TrackReservationSlot trackReservationSlot =
+                TrackReservationSlot.builder()
+                        .track(track)
+                        .trackReservation(trackReservation)
+                        .startedAt(startedAt)
+                        .expiredAt(expiredAt)
+                        .build();
+
+        // then
+        assertThat(trackReservationSlot.getTrack()).isEqualTo(track);
+        assertThat(trackReservationSlot.getTrackReservation()).isEqualTo(trackReservation);
+        assertThat(trackReservationSlot.getStartedAt()).isEqualTo(startedAt);
+        assertThat(trackReservationSlot.getExpiredAt()).isEqualTo(expiredAt);
+    }
+}

--- a/src/test/java/com/testcar/car/domains/trackReservation/entity/TrackReservationTest.java
+++ b/src/test/java/com/testcar/car/domains/trackReservation/entity/TrackReservationTest.java
@@ -7,6 +7,8 @@ import com.testcar.car.common.TrackEntityFactory;
 import com.testcar.car.domains.member.Member;
 import com.testcar.car.domains.track.Track;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class TrackReservationTest {
     @Test
@@ -36,5 +38,37 @@ public class TrackReservationTest {
 
         // then
         assertThat(trackReservation.getStatus()).isEqualTo(ReservationStatus.CANCELED);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ReservationStatus.class,
+            names = {"RESERVED", "USING"})
+    public void 시험장을_취소할수_있는지_확인한다(ReservationStatus status) {
+        // given
+        final TrackReservation trackReservation =
+                TrackEntityFactory.createTrackReservationBuilder().status(status).build();
+
+        // when
+        final boolean isCancelable = trackReservation.isCancelable();
+
+        // then
+        assertThat(isCancelable).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ReservationStatus.class,
+            names = {"CANCELED", "COMPLETED"})
+    public void 시험장을_취소할수_없는지_확인한다(ReservationStatus status) {
+        // given
+        final TrackReservation trackReservation =
+                TrackEntityFactory.createTrackReservationBuilder().status(status).build();
+
+        // when
+        final boolean isCancelable = trackReservation.isCancelable();
+
+        // then
+        assertThat(isCancelable).isFalse();
     }
 }

--- a/src/test/java/com/testcar/car/domains/trackReservation/entity/TrackReservationTest.java
+++ b/src/test/java/com/testcar/car/domains/trackReservation/entity/TrackReservationTest.java
@@ -1,0 +1,40 @@
+package com.testcar.car.domains.trackReservation.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.testcar.car.common.MemberEntityFactory;
+import com.testcar.car.common.TrackEntityFactory;
+import com.testcar.car.domains.member.Member;
+import com.testcar.car.domains.track.Track;
+import org.junit.jupiter.api.Test;
+
+public class TrackReservationTest {
+    @Test
+    public void 시험장_예약정보_엔티티를_생성한다() {
+        // given
+        final Member member = MemberEntityFactory.createMember();
+        final Track track = TrackEntityFactory.createTrack();
+        final ReservationStatus status = ReservationStatus.RESERVED;
+
+        // when
+        final TrackReservation trackReservation =
+                TrackReservation.builder().member(member).track(track).status(status).build();
+
+        // then
+        assertThat(trackReservation.getMember()).isEqualTo(member);
+        assertThat(trackReservation.getTrack()).isEqualTo(track);
+        assertThat(trackReservation.getStatus()).isEqualTo(status);
+    }
+
+    @Test
+    public void 시험장_예약을_취소한다() {
+        // given
+        final TrackReservation trackReservation = TrackEntityFactory.createTrackReservation();
+
+        // when
+        trackReservation.cancel();
+
+        // then
+        assertThat(trackReservation.getStatus()).isEqualTo(ReservationStatus.CANCELED);
+    }
+}


### PR DESCRIPTION
- 시험장의 각 엔티티에 대한 단위 테스트 구현했습니다
- 시험장 서비스 로직에 대한 단위 테스트 구현했습니다
- 엔티티와 요청을 팩토리 클래스에서 가져오도록 하여 가독성을 향상시켰습니다.
- 테스트 과정에서 생긴 버그를 수정하였습니다.
  - 예약 중이지 않은 상태의 시험장 예약을 반납할 수 있는 오류
- 시험장 예약 시간 슬롯 메소드의 단위를 분리했습니다.