### PR TITLE
test: 사용자 단위 테스트 구현

### DIFF
--- a/src/main/java/com/testcar/car/domains/member/MemberService.java
+++ b/src/main/java/com/testcar/car/domains/member/MemberService.java
@@ -11,6 +11,7 @@ import com.testcar.car.domains.member.model.RegisterMemberRequest;
 import com.testcar.car.domains.member.model.UpdateMemberRequest;
 import com.testcar.car.domains.member.model.vo.MemberFilterCondition;
 import com.testcar.car.domains.member.repository.MemberRepository;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -56,7 +57,7 @@ public class MemberService {
 
     /** 계정을 삭제 처리 합니다. (soft delete) */
     public Member deleteById(Member member, Long memberId) {
-        if (member.getId() == memberId) {
+        if (Objects.equals(member.getId(), memberId)) {
             throw new BadRequestException(ErrorCode.CANNOT_DELETE_MYSELF);
         }
         final Member deleteMember = this.findById(memberId);

--- a/src/test/java/com/testcar/car/common/Constant.java
+++ b/src/test/java/com/testcar/car/common/Constant.java
@@ -17,10 +17,12 @@ public class Constant {
     public static final LocalDateTime YESTERDAY = NOW.minusDays(1L);
 
     /** Member */
-    public static final String MEMBER_EMAIL = "test@test.com";
-
-    public static final String MEMBER_PASSWORD = "1234abcd@";
     public static final String MEMBER_NAME = "홍길동";
+
+    public static final String ANOTHER_MEMBER_NAME = "동길홍";
+    public static final String MEMBER_EMAIL = "test@test.com";
+    public static final String ANOTHER_MEMBER_EMAIL = "car@car.com";
+    public static final String MEMBER_PASSWORD = "1234abcd@";
     public static final Role MEMBER_ROLE = Role.ADMIN;
     public static final String DEPARTMENT_NAME = "모비스시스템팀";
 

--- a/src/test/java/com/testcar/car/domains/car/CarServiceTest.java
+++ b/src/test/java/com/testcar/car/domains/car/CarServiceTest.java
@@ -83,6 +83,7 @@ public class CarServiceTest {
 
         // then
         assertEquals(mockPage, result);
+        verify(carRepository).findAllPageByCondition(condition, pageable);
     }
 
     @Test

--- a/src/test/java/com/testcar/car/domains/car/TestCarServiceTest.java
+++ b/src/test/java/com/testcar/car/domains/car/TestCarServiceTest.java
@@ -75,5 +75,6 @@ public class TestCarServiceTest {
 
         // then
         assertEquals(mockPage, result);
+        verify(carRepository).findAllWithStocksPageByCondition(condition, pageable);
     }
 }

--- a/src/test/java/com/testcar/car/domains/carReservation/CarReservationServiceTest.java
+++ b/src/test/java/com/testcar/car/domains/carReservation/CarReservationServiceTest.java
@@ -79,6 +79,7 @@ public class CarReservationServiceTest {
 
         // then
         assertEquals(mockPage, result);
+        verify(carReservationRepository).findAllPageByCondition(condition, pageable);
     }
 
     @Test

--- a/src/test/java/com/testcar/car/domains/carStock/CarStockServiceTest.java
+++ b/src/test/java/com/testcar/car/domains/carStock/CarStockServiceTest.java
@@ -163,6 +163,7 @@ public class CarStockServiceTest {
 
         // then
         assertEquals(mockPage, result);
+        verify(carStockRepository).findAllPageByCondition(condition, pageable);
     }
 
     @Test

--- a/src/test/java/com/testcar/car/domains/carTest/CarTestServiceTest.java
+++ b/src/test/java/com/testcar/car/domains/carTest/CarTestServiceTest.java
@@ -87,6 +87,7 @@ public class CarTestServiceTest {
 
         // Then
         assertEquals(mockPage, result);
+        verify(carTestRepository).findAllPageByCondition(condition, pageable);
     }
 
     @Test

--- a/src/test/java/com/testcar/car/domains/department/DepartmentServiceTest.java
+++ b/src/test/java/com/testcar/car/domains/department/DepartmentServiceTest.java
@@ -1,0 +1,102 @@
+package com.testcar.car.domains.department;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.when;
+
+import com.testcar.car.common.MemberEntityFactory;
+import com.testcar.car.common.exception.BadRequestException;
+import com.testcar.car.common.exception.NotFoundException;
+import com.testcar.car.domains.department.entity.Department;
+import com.testcar.car.domains.department.model.CreateDepartmentRequest;
+import com.testcar.car.domains.department.repository.DepartmentRepository;
+import com.testcar.car.domains.department.request.DepartmentRequestFactory;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DepartmentServiceTest {
+    @Mock private DepartmentRepository departmentRepository;
+    @InjectMocks private DepartmentService departmentService;
+
+    private static Department department;
+    private static final Long departmentId = 1L;
+
+    @BeforeAll
+    public static void setUp() {
+        department = MemberEntityFactory.createDepartment();
+    }
+
+    @Test
+    void 부서ID로_DB에서_부서_엔티티를_가져온다() {
+        // given
+        when(departmentRepository.findByIdAndDeletedFalse(departmentId))
+                .thenReturn(Optional.of(department));
+
+        // when
+        final Department result = departmentService.findById(departmentId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(department, result);
+        then(departmentRepository).should().findByIdAndDeletedFalse(departmentId);
+    }
+
+    @Test
+    void 부서_ID에_해당하는_정보가_DB에_존재하지_않으면_오류가_발생한다() {
+        // given
+        when(departmentRepository.findByIdAndDeletedFalse(departmentId))
+                .thenReturn(Optional.empty());
+
+        // when, then
+        Assertions.assertThrows(
+                NotFoundException.class,
+                () -> {
+                    departmentService.findById(departmentId);
+                });
+        then(departmentRepository).should().findByIdAndDeletedFalse(departmentId);
+    }
+
+    @Test
+    void 새로운_부서를_생성한다() {
+        // given
+        final CreateDepartmentRequest request =
+                DepartmentRequestFactory.createDepartmentRequestFactory();
+        when(departmentRepository.save(any(Department.class))).thenReturn(department);
+        when(departmentRepository.existsByNameAndDeletedFalse(request.getName())).thenReturn(false);
+
+        // when
+        final Department result = departmentService.create(request);
+
+        // then
+        assertNotNull(result);
+        assertEquals(department, result);
+        then(departmentRepository).should().save(any(Department.class));
+        then(departmentRepository).should().existsByNameAndDeletedFalse(request.getName());
+    }
+
+    @Test
+    void 부서명이_중복되면_오류가_발생한다() {
+        // given
+        final CreateDepartmentRequest request =
+                DepartmentRequestFactory.createDepartmentRequestFactory();
+        when(departmentRepository.existsByNameAndDeletedFalse(request.getName())).thenReturn(true);
+
+        // when, then
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> {
+                    departmentService.create(request);
+                });
+        then(departmentRepository).should().existsByNameAndDeletedFalse(request.getName());
+        then(departmentRepository).shouldHaveNoMoreInteractions();
+    }
+}

--- a/src/test/java/com/testcar/car/domains/department/entity/DepartmentTest.java
+++ b/src/test/java/com/testcar/car/domains/department/entity/DepartmentTest.java
@@ -1,0 +1,21 @@
+package com.testcar.car.domains.department.entity;
+
+import static com.testcar.car.common.Constant.DEPARTMENT_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class DepartmentTest {
+    @Test
+    public void 새로운_부서를_생성한다() {
+        // given
+        final String name = DEPARTMENT_NAME;
+
+        // when
+        final Department result = Department.builder().name(name).build();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo(name);
+    }
+}

--- a/src/test/java/com/testcar/car/domains/department/request/DepartmentRequestFactory.java
+++ b/src/test/java/com/testcar/car/domains/department/request/DepartmentRequestFactory.java
@@ -1,0 +1,13 @@
+package com.testcar.car.domains.department.request;
+
+import static com.testcar.car.common.Constant.DEPARTMENT_NAME;
+
+import com.testcar.car.domains.department.model.CreateDepartmentRequest;
+
+public class DepartmentRequestFactory {
+    private DepartmentRequestFactory() {}
+
+    public static CreateDepartmentRequest createDepartmentRequestFactory() {
+        return CreateDepartmentRequest.builder().name(DEPARTMENT_NAME).build();
+    }
+}

--- a/src/test/java/com/testcar/car/domains/member/MemberServiceTest.java
+++ b/src/test/java/com/testcar/car/domains/member/MemberServiceTest.java
@@ -1,0 +1,192 @@
+package com.testcar.car.domains.member;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.testcar.car.common.MemberEntityFactory;
+import com.testcar.car.common.exception.BadRequestException;
+import com.testcar.car.common.exception.NotFoundException;
+import com.testcar.car.domains.department.DepartmentService;
+import com.testcar.car.domains.department.entity.Department;
+import com.testcar.car.domains.member.model.RegisterMemberRequest;
+import com.testcar.car.domains.member.model.UpdateMemberRequest;
+import com.testcar.car.domains.member.model.vo.MemberFilterCondition;
+import com.testcar.car.domains.member.repository.MemberRepository;
+import com.testcar.car.domains.member.request.MemberRequestFactory;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceTest {
+    @Mock private DepartmentService departmentService;
+    @Mock private MemberRepository memberRepository;
+    @Mock private static Member mockMember;
+    @InjectMocks private MemberService memberService;
+
+    private static Member member;
+    private static Department department;
+    private static Department anotherDepartment;
+    private static final Long memberId = 1L;
+    private static final Long anotherMemberId = 2L;
+
+    @BeforeAll
+    public static void setUp() {
+        member = MemberEntityFactory.createMember();
+        department = MemberEntityFactory.createDepartment();
+        anotherDepartment = MemberEntityFactory.createDepartment();
+    }
+
+    @Test
+    void 사용자ID로_DB에서_사용자_엔티티를_가져온다() {
+        // given
+        when(memberRepository.findByIdAndDeletedFalse(memberId)).thenReturn(Optional.of(member));
+
+        // when
+        final Member result = memberService.findById(memberId);
+
+        // then
+        assertEquals(member, result);
+        verify(memberRepository).findByIdAndDeletedFalse(memberId);
+    }
+
+    @Test
+    void 해당_ID의_사용자가_DB에_존재하지_않으면_오류가_발생한다() {
+        // given
+        when(memberRepository.findByIdAndDeletedFalse(memberId)).thenReturn(Optional.empty());
+
+        // when, then
+        Assertions.assertThrows(
+                NotFoundException.class,
+                () -> {
+                    memberService.findById(memberId);
+                });
+    }
+
+    @Test
+    void 조건에_맞는_사용자_페이지를_필터링하여_가져온다() {
+        // given
+        MemberFilterCondition condition = new MemberFilterCondition();
+        Pageable pageable = mock(Pageable.class);
+        Page<Member> mockPage = mock(Page.class);
+        when(memberRepository.findAllPageByCondition(condition, pageable)).thenReturn(mockPage);
+
+        // when
+        final Page<Member> result = memberService.findAllPageByCondition(condition, pageable);
+
+        // then
+        assertEquals(mockPage, result);
+        verify(memberRepository).findAllPageByCondition(condition, pageable);
+    }
+
+    @Test
+    void 새로운_사용자를_등록한다() {
+        // given
+        final RegisterMemberRequest request = MemberRequestFactory.createMemberRequest();
+        when(departmentService.findById(request.getDepartmentId())).thenReturn(department);
+        given(memberRepository.save(any(Member.class))).willReturn(member);
+
+        // when
+        final Member newMember = memberService.register(request);
+
+        // then
+        assertNotNull(newMember);
+        assertEquals(member, newMember);
+        then(departmentService).should().findById(any(Long.class));
+        then(memberRepository).should().save(any(Member.class));
+    }
+
+    @Test
+    void DB에_이미_존재하는_이메일로는_등록할수_없다() {
+        // given
+        final RegisterMemberRequest request = MemberRequestFactory.createMemberRequest();
+        when(memberRepository.existsByEmailAndDeletedFalse(request.getEmail())).thenReturn(true);
+
+        // when, then
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> {
+                    memberService.register(request);
+                });
+    }
+
+    @Test
+    void 사용자_정보를_수정한다() {
+        // given
+        final UpdateMemberRequest request = MemberRequestFactory.createUpdateMemberRequest();
+        when(departmentService.findById(request.getDepartmentId())).thenReturn(anotherDepartment);
+        when(memberRepository.findByIdAndDeletedFalse(memberId)).thenReturn(Optional.of(member));
+        given(memberRepository.save(any(Member.class))).willReturn(member);
+
+        // when
+        final Member newMember = memberService.updateById(memberId, request);
+
+        // then
+        assertNotNull(newMember);
+        assertEquals(anotherDepartment, newMember.getDepartment());
+        assertEquals(request.getEmail(), newMember.getEmail());
+        assertEquals(request.getName(), newMember.getName());
+        assertEquals(request.getRole(), newMember.getRole());
+        then(memberRepository).should().findByIdAndDeletedFalse(any(Long.class));
+        then(memberRepository).should().save(any(Member.class));
+    }
+
+    @Test
+    void DB에_이미_존재하는_이메일로는_변경할수_없다() {
+        // given
+        final UpdateMemberRequest request = MemberRequestFactory.createInvalidUpdateMemberRequest();
+        when(memberRepository.findByIdAndDeletedFalse(memberId)).thenReturn(Optional.of(member));
+        when(departmentService.findById(request.getDepartmentId())).thenReturn(anotherDepartment);
+        when(memberRepository.existsByEmailAndDeletedFalse(request.getEmail())).thenReturn(true);
+
+        // when, then
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> {
+                    memberService.updateById(memberId, request);
+                });
+    }
+
+    @Test
+    void 사용자를_삭제한다() {
+        // given
+        when(memberRepository.findByIdAndDeletedFalse(memberId)).thenReturn(Optional.of(member));
+        when(memberRepository.save(any(Member.class))).thenReturn(member);
+
+        // when
+        final Member deletedMember = memberService.deleteById(member, memberId);
+
+        // then
+        assertTrue(deletedMember.getDeleted());
+        verify(memberRepository).findByIdAndDeletedFalse(memberId);
+        verify(memberRepository).save(any(Member.class));
+    }
+
+    @Test
+    void 자기_자신은_삭제할수_없다() {
+        // given
+        when(mockMember.getId()).thenReturn(1L);
+
+        // when
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> {
+                    memberService.deleteById(mockMember, memberId);
+                });
+        then(memberRepository).shouldHaveNoMoreInteractions();
+    }
+}

--- a/src/test/java/com/testcar/car/domains/member/entity/MemberTest.java
+++ b/src/test/java/com/testcar/car/domains/member/entity/MemberTest.java
@@ -1,0 +1,65 @@
+package com.testcar.car.domains.member.entity;
+
+import static com.testcar.car.common.Constant.ANOTHER_MEMBER_NAME;
+import static com.testcar.car.common.Constant.MEMBER_EMAIL;
+import static com.testcar.car.common.Constant.MEMBER_NAME;
+import static com.testcar.car.common.Constant.MEMBER_PASSWORD;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.testcar.car.common.MemberEntityFactory;
+import com.testcar.car.domains.department.entity.Department;
+import com.testcar.car.domains.member.Member;
+import com.testcar.car.domains.member.Role;
+import org.junit.jupiter.api.Test;
+
+public class MemberTest {
+    @Test
+    public void 새로운_사용자를_생성한다() {
+        // given
+        final String name = MEMBER_NAME;
+        final Department department = MemberEntityFactory.createDepartment();
+        final String password = MEMBER_PASSWORD;
+        final String email = MEMBER_EMAIL;
+        final Role role = Role.ADMIN;
+
+        // when
+        final Member member =
+                Member.builder()
+                        .name(name)
+                        .department(department)
+                        .password(password)
+                        .email(email)
+                        .role(role)
+                        .build();
+        // then
+        assertThat(member.getName()).isEqualTo(name);
+        assertThat(member.getDepartment()).isEqualTo(department);
+        assertThat(member.getPassword()).isEqualTo(password);
+        assertThat(member.getEmail()).isEqualTo(email);
+        assertThat(member.getRole()).isEqualTo(role);
+    }
+
+    @Test
+    public void 사용자_정보를_변경한다() {
+        // given
+        final Member member = MemberEntityFactory.createMember();
+        final Member updatedMember =
+                Member.builder()
+                        .name(ANOTHER_MEMBER_NAME)
+                        .department(MemberEntityFactory.createDepartment())
+                        .password(MEMBER_PASSWORD)
+                        .email(MEMBER_EMAIL)
+                        .role(Role.USER)
+                        .build();
+
+        // when
+        member.update(updatedMember);
+
+        // then
+        assertThat(member.getName()).isEqualTo(updatedMember.getName());
+        assertThat(member.getDepartment()).isEqualTo(updatedMember.getDepartment());
+        assertThat(member.getPassword()).isEqualTo(updatedMember.getPassword());
+        assertThat(member.getEmail()).isEqualTo(updatedMember.getEmail());
+        assertThat(member.getRole()).isEqualTo(updatedMember.getRole());
+    }
+}

--- a/src/test/java/com/testcar/car/domains/member/request/MemberRequestFactory.java
+++ b/src/test/java/com/testcar/car/domains/member/request/MemberRequestFactory.java
@@ -1,0 +1,43 @@
+package com.testcar.car.domains.member.request;
+
+import static com.testcar.car.common.Constant.ANOTHER_MEMBER_EMAIL;
+import static com.testcar.car.common.Constant.ANOTHER_MEMBER_NAME;
+import static com.testcar.car.common.Constant.MEMBER_EMAIL;
+import static com.testcar.car.common.Constant.MEMBER_NAME;
+import static com.testcar.car.common.Constant.MEMBER_PASSWORD;
+
+import com.testcar.car.domains.member.Role;
+import com.testcar.car.domains.member.model.RegisterMemberRequest;
+import com.testcar.car.domains.member.model.UpdateMemberRequest;
+
+public class MemberRequestFactory {
+    private MemberRequestFactory() {}
+
+    public static RegisterMemberRequest createMemberRequest() {
+        return RegisterMemberRequest.builder()
+                .departmentId(1L)
+                .name(MEMBER_NAME)
+                .email(MEMBER_EMAIL)
+                .password(MEMBER_PASSWORD)
+                .role(Role.ADMIN)
+                .build();
+    }
+
+    public static UpdateMemberRequest createUpdateMemberRequest() {
+        return UpdateMemberRequest.builder()
+                .departmentId(2L)
+                .name(ANOTHER_MEMBER_NAME)
+                .email(ANOTHER_MEMBER_EMAIL)
+                .role(Role.ADMIN)
+                .build();
+    }
+
+    public static UpdateMemberRequest createInvalidUpdateMemberRequest() {
+        return UpdateMemberRequest.builder()
+                .departmentId(2L)
+                .name(ANOTHER_MEMBER_NAME)
+                .email(MEMBER_EMAIL)
+                .role(Role.ADMIN)
+                .build();
+    }
+}


### PR DESCRIPTION
- 사용자와 관련 서비스 로직에 대한 단위 테스트를 구현했습니다.
- 부서에 대한 단위 테스트를 구현했습니다.
- 사용자 id 비교 로직에 equals 를 적용했습니다.
- 타 단위 테스트의 verify 로직을 일부 적용했습니다.