### PR TITLE
feat: 분산락 aop 구현

### DIFF
--- a/src/main/java/com/testcar/car/common/annotation/DistributedLock.java
+++ b/src/main/java/com/testcar/car/common/annotation/DistributedLock.java
@@ -1,0 +1,17 @@
+package com.testcar.car.common.annotation;
+
+
+import com.testcar.car.common.database.DistributedLockType;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** 분산 락을 걸기 위한 어노테이션 */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+    DistributedLockType type();
+
+    String identifier();
+}

--- a/src/main/java/com/testcar/car/common/database/DistributedLockAop.java
+++ b/src/main/java/com/testcar/car/common/database/DistributedLockAop.java
@@ -1,0 +1,63 @@
+package com.testcar.car.common.database;
+
+
+import com.testcar.car.common.annotation.DistributedLock;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/** 분산락 어노테이션에 대한 AOP */
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+@SuppressWarnings("unchecked")
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)
+public class DistributedLockAop {
+    private final LockManager lockManager;
+
+    @Around("@annotation(distributedLock)")
+    public void lock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) {
+        final String key = createDynamicKey(joinPoint, distributedLock);
+        lockManager.lock(
+                key,
+                () -> {
+                    try {
+                        return joinPoint.proceed();
+                    } catch (Throwable throwable) {
+                        throw new InvalidLockException("Lock Error", throwable);
+                    }
+                });
+    }
+
+    private String createDynamicKey(
+            ProceedingJoinPoint joinPoint, DistributedLock distributedLock) {
+        final String identifier = distributedLock.identifier();
+        final DistributedLockType type = distributedLock.type();
+        final Long id = findArgumentByName(joinPoint, identifier);
+        return String.format("%s:%d", type.getLockName(), id);
+    }
+
+    public static <T> T findArgumentByName(JoinPoint joinPoint, String name) {
+        try {
+            final MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+            final List<String> parameterNames = Arrays.asList(signature.getParameterNames());
+            final List<Object> methodArguments = Arrays.asList(joinPoint.getArgs());
+
+            final int parameterIndex = parameterNames.indexOf(name);
+            return (T) methodArguments.get(parameterIndex);
+        } catch (Exception e) {
+            log.error("Reflection Error", e);
+            throw new InvalidLockException("올바르지 않은 인수명입니다. " + name);
+        }
+    }
+}

--- a/src/main/java/com/testcar/car/common/database/DistributedLockType.java
+++ b/src/main/java/com/testcar/car/common/database/DistributedLockType.java
@@ -1,0 +1,14 @@
+package com.testcar.car.common.database;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum DistributedLockType {
+    TRACK("track"),
+    CAR("car");
+
+    private final String lockName;
+}

--- a/src/main/java/com/testcar/car/common/database/InvalidLockException.java
+++ b/src/main/java/com/testcar/car/common/database/InvalidLockException.java
@@ -1,0 +1,11 @@
+package com.testcar.car.common.database;
+
+public class InvalidLockException extends RuntimeException {
+    public InvalidLockException(String message) {
+        super(message);
+    }
+
+    public InvalidLockException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/testcar/car/common/database/LockManager.java
+++ b/src/main/java/com/testcar/car/common/database/LockManager.java
@@ -1,0 +1,9 @@
+package com.testcar.car.common.database;
+
+
+import java.util.function.Supplier;
+
+/** 분산 락 관련 메소드 인터페이스 */
+public interface LockManager {
+    <T> T lock(String lockName, Supplier<T> runnable);
+}

--- a/src/main/java/com/testcar/car/common/database/NamedLockManager.java
+++ b/src/main/java/com/testcar/car/common/database/NamedLockManager.java
@@ -1,0 +1,77 @@
+package com.testcar.car.common.database;
+
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.Supplier;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** MySQL 의 NamedLock 관련 메소드 클래스 */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NamedLockManager implements LockManager {
+    private static final String GET_LOCK = "SELECT GET_LOCK(?, ?)";
+    private static final String RELEASE_LOCK = "SELECT RELEASE_LOCK(?)";
+    private static final String NULL_EXCEPTION = "잘못된 인자입니다.";
+    private static final String EMPTY_EXCEPTION = "잘못된 키값입니다.";
+    private static final int TIMEOUT_SECONDS = 10;
+    private final DataSource dataSource;
+
+    @Transactional(propagation = Propagation.NEVER)
+    public <T> T lock(String userLockName, Supplier<T> supplier) {
+        try (Connection connection = dataSource.getConnection()) {
+            try {
+                getLock(connection, userLockName);
+                return supplier.get();
+            } finally {
+                releaseLock(connection, userLockName);
+            }
+        } catch (SQLException | RuntimeException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    private void getLock(Connection connection, String userLockName) {
+
+        try (PreparedStatement preparedStatement = connection.prepareStatement(GET_LOCK)) {
+            preparedStatement.setString(1, userLockName);
+            preparedStatement.setInt(2, TIMEOUT_SECONDS);
+
+            validateLockStatement(preparedStatement);
+        } catch (SQLException e) {
+            log.error("releaseLock Error", e);
+            throw new InvalidLockException(e.getMessage(), e);
+        }
+    }
+
+    private void releaseLock(Connection connection, String userLockName) {
+        try (PreparedStatement preparedStatement = connection.prepareStatement(RELEASE_LOCK)) {
+            preparedStatement.setString(1, userLockName);
+
+            validateLockStatement(preparedStatement);
+        } catch (SQLException e) {
+            log.error("releaseLock Error", e);
+            throw new InvalidLockException(e.getMessage(), e);
+        }
+    }
+
+    private void validateLockStatement(PreparedStatement preparedStatement) throws SQLException {
+        try (ResultSet resultSet = preparedStatement.executeQuery()) {
+            if (!resultSet.next()) {
+                throw new InvalidLockException(NULL_EXCEPTION);
+            }
+            int result = resultSet.getInt(1);
+            if (result != 1) {
+                throw new InvalidLockException(EMPTY_EXCEPTION);
+            }
+        }
+    }
+}

--- a/src/main/java/com/testcar/car/domains/carReservation/CarReservationController.java
+++ b/src/main/java/com/testcar/car/domains/carReservation/CarReservationController.java
@@ -42,7 +42,8 @@ public class CarReservationController {
     @Operation(summary = "[대여] 시험 차량 대여", description = "시험 차량을 예약합니다.")
     public CarReservationResponse postCarReservation(
             @AuthMember Member member, @Valid @RequestBody CarReservationRequest request) {
-        final CarReservation carReservation = carReservationService.reserve(member, request);
+        final CarReservation carReservation =
+                carReservationService.reserve(member, request.getCarStockId());
         return CarReservationResponse.from(carReservation);
     }
 

--- a/src/main/java/com/testcar/car/domains/carReservation/CarReservationService.java
+++ b/src/main/java/com/testcar/car/domains/carReservation/CarReservationService.java
@@ -3,12 +3,13 @@ package com.testcar.car.domains.carReservation;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 
+import com.testcar.car.common.annotation.DistributedLock;
+import com.testcar.car.common.database.DistributedLockType;
 import com.testcar.car.common.exception.BadRequestException;
 import com.testcar.car.common.exception.NotFoundException;
 import com.testcar.car.domains.carReservation.entity.CarReservation;
 import com.testcar.car.domains.carReservation.entity.ReservationStatus;
 import com.testcar.car.domains.carReservation.exception.ErrorCode;
-import com.testcar.car.domains.carReservation.model.CarReservationRequest;
 import com.testcar.car.domains.carReservation.model.ReturnCarReservationRequest;
 import com.testcar.car.domains.carReservation.model.dto.CarReservationDto;
 import com.testcar.car.domains.carReservation.model.vo.CarReservationCountVo;
@@ -74,8 +75,9 @@ public class CarReservationService {
     }
 
     /** 시험차량을 예약합니다. */
-    public CarReservation reserve(Member member, CarReservationRequest request) {
-        final CarStock carStock = carStockService.findById(request.getCarStockId());
+    @DistributedLock(type = DistributedLockType.TRACK, identifier = "carStockId")
+    public CarReservation reserve(Member member, Long carStockId) {
+        final CarStock carStock = carStockService.findById(carStockId);
         validateCarStockAvailable(carStock);
         final LocalDateTime now = LocalDateTime.now();
         final LocalDateTime expiredAt = now.toLocalDate().plusDays(RESERVATION_DATE).atStartOfDay();

--- a/src/main/java/com/testcar/car/domains/trackReservation/TrackReservationService.java
+++ b/src/main/java/com/testcar/car/domains/trackReservation/TrackReservationService.java
@@ -5,6 +5,8 @@ import static com.testcar.car.domains.trackReservation.exception.ErrorCode.TRACK
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 
+import com.testcar.car.common.annotation.DistributedLock;
+import com.testcar.car.common.database.DistributedLockType;
 import com.testcar.car.common.exception.BadRequestException;
 import com.testcar.car.common.exception.NotFoundException;
 import com.testcar.car.domains.member.entity.Member;
@@ -72,6 +74,7 @@ public class TrackReservationService {
     }
 
     /** 해당 시험장을 예약합니다. */
+    @DistributedLock(type = DistributedLockType.TRACK, identifier = "trackId")
     public TrackReservation reserve(Member member, Long trackId, TrackReservationRequest request) {
         final Track track = trackService.findById(trackId);
         final TrackReservation trackReservation =

--- a/src/test/java/com/testcar/car/domains/carReservation/CarReservationServiceTest.java
+++ b/src/test/java/com/testcar/car/domains/carReservation/CarReservationServiceTest.java
@@ -147,7 +147,8 @@ public class CarReservationServiceTest {
         when(carStockService.findById(request.getCarStockId())).thenReturn(carStock);
 
         // when
-        CarReservation newCarReservation = carReservationService.reserve(member, request);
+        CarReservation newCarReservation =
+                carReservationService.reserve(member, request.getCarStockId());
 
         // then
         then(carReservationRepository).should().save(any(CarReservation.class));
@@ -168,7 +169,7 @@ public class CarReservationServiceTest {
         Assertions.assertThrows(
                 BadRequestException.class,
                 () -> {
-                    carReservationService.reserve(member, request);
+                    carReservationService.reserve(member, request.getCarStockId());
                 });
         then(carStockService).should().findById(any(Long.class));
         then(carReservationRepository).shouldHaveNoMoreInteractions();


### PR DESCRIPTION
- MySQL 의 NamedLock 을 이용한 분산락을 구현했습니다
- AOP 기반으로 관심사를 분리하여 여러 곳에서 사용할 수 있도록 했습니다

Jmeter 부하 테스트로 분산락 적용 테스트를 수행했습니다

- 분산락 미적용 (2개 이상의 예약이 동시에 수행될 수 있음)
<img width="999" alt="스크린샷 2023-12-21 20 42 03" src="https://github.com/test-car-managing-system/backend/assets/72291860/1dda15c1-7df4-41d3-b5d4-3ed661ddbdd5">


- 분산락 적용 (하나의 예약만 이루어짐)

<img width="1594" alt="스크린샷 2023-12-21 20 54 49" src="https://github.com/test-car-managing-system/backend/assets/72291860/19bb710d-a507-48bb-ae5a-a7fc855cff91">
