### PR TITLE
fix: 정렬 순서 변경

### DIFF
--- a/src/main/java/com/testcar/car/domains/gasStation/GasStationService.java
+++ b/src/main/java/com/testcar/car/domains/gasStation/GasStationService.java
@@ -29,7 +29,7 @@ public class GasStationService {
 
     /** 등록된 모든 주유소를 조회합니다. */
     public List<GasStation> findAll() {
-        return gasStationRepository.findAllByDeletedFalse();
+        return gasStationRepository.findAllByDeletedFalseOrderByCreatedAtDesc();
     }
 
     /** 주유소를 id로 조회합니다. */

--- a/src/main/java/com/testcar/car/domains/gasStation/repository/GasStationRepository.java
+++ b/src/main/java/com/testcar/car/domains/gasStation/repository/GasStationRepository.java
@@ -11,7 +11,7 @@ public interface GasStationRepository extends JpaRepository<GasStation, Long> {
 
     Optional<GasStation> findByNameAndDeletedFalse(String name);
 
-    List<GasStation> findAllByDeletedFalse();
+    List<GasStation> findAllByDeletedFalseOrderByCreatedAtDesc();
 
     List<GasStation> findAllByIdInAndDeletedFalse(List<Long> ids);
 

--- a/src/main/java/com/testcar/car/domains/member/repository/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/testcar/car/domains/member/repository/MemberCustomRepositoryImpl.java
@@ -44,6 +44,7 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository, BaseQ
                         .leftJoin(member.department, department)
                         .fetchJoin()
                         .where(member.id.in(coveringIndex))
+                        .orderBy(member.name.asc(), member.createdAt.desc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize())
                         .fetch();

--- a/src/test/java/com/testcar/car/domains/gasStation/GasStationServiceTest.java
+++ b/src/test/java/com/testcar/car/domains/gasStation/GasStationServiceTest.java
@@ -72,14 +72,15 @@ public class GasStationServiceTest {
     @Test
     void 등록된_모든_주유소를_DB에서_조회한다() {
         // given
-        when(gasStationRepository.findAllByDeletedFalse()).thenReturn(List.of(gasStation));
+        when(gasStationRepository.findAllByDeletedFalseOrderByCreatedAtDesc())
+                .thenReturn(List.of(gasStation));
 
         // when
         final List<GasStation> result = gasStationService.findAll();
 
         // then
         assertEquals(List.of(gasStation), result);
-        verify(gasStationRepository).findAllByDeletedFalse();
+        verify(gasStationRepository).findAllByDeletedFalseOrderByCreatedAtDesc();
     }
 
     @Test


### PR DESCRIPTION
- 주유소, 유저 조회 시 정렬 순서를 변경했습니다
- 주유소: 등록일자 최신순
- 유저: 이름 가나다순, 이후 등록일자 최신순